### PR TITLE
feat: Update readme for Cursor and VS code installation

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -70,7 +70,8 @@ Add to your MCP client configuration file:
    - [PAT v2](https://docs.esa.io/posts/559) is recommended.
 - LANG: Language for UI
 
-### Claude Desktop Example
+<details>
+<summary><b>Install in Claude Desktop</b></summary>
 
 Add to `claude_desktop_config.json`:
 
@@ -106,7 +107,7 @@ Add to `claude_desktop_config.json`:
 {
   "mcpServers": {
     "esa": {
-      "command": "/Users/your-username/.nodenv/shims/npx",
+      "command": "/path/to/your/npx",
       "args": [
         "@esaio/esa-mcp-server"
       ],
@@ -119,7 +120,71 @@ Add to `claude_desktop_config.json`:
 }
 ```
 
-> **Note**: Replace `/path/to/your/node` with the output of `which node` command.
+> **Note**: Replace `/path/to/your/npx` with the output of `which npx` command.
+
+
+</details>
+
+
+<details>
+<summary><b>Install in Cursor</b></summary>
+
+Go to: `Settings` -> `Cursor Settings` -> `MCP` -> `Add new global MCP server`
+
+Pasting the following configuration into your Cursor `~/.cursor/mcp.json` file is the recommended approach. You may also install in a specific project by creating `.cursor/mcp.json` in your project folder. See [Cursor MCP docs](https://docs.cursor.com/context/model-context-protocol) for more info.
+
+
+#### Cursor Local Server Connection with `npx`
+
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=esa&config=ewogICAgICAiY29tbWFuZCI6ICJucHgiLAogICAgICAiYXJncyI6IFsKICAgICAgICAiQGVzYWlvL2VzYS1tY3Atc2VydmVyIgogICAgICBdLAogICAgICAiZW52IjogewogICAgICAgICJFU0FfQUNDRVNTX1RPS0VOIjogInlvdXJfcGVyc29uYWxfYWNjZXNzX3Rva2VuIiwKICAgICAgICAiTEFORyI6ICJlbiIKICAgICAgfQogICAgfQ==)
+
+```json
+{
+  "mcpServers": {
+    "esa": {
+      "command": "npx",
+      "args": [
+        "@esaio/esa-mcp-server"
+      ],
+      "env": {
+        "ESA_ACCESS_TOKEN": "your_personal_access_token",
+        "LANG": "en"
+      }
+    },
+  }
+}
+
+```
+
+</details>
+
+<details>
+<summary><b>Install in VS Code</b></summary>
+
+[<img alt="Install in VS Code (npx)" src="https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square&label=Install%20Esa%20MCP&color=0098FF">](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%7B%22name%22%3A%22esa%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22%40esaio%2Fesa-mcp-server%40latest%22%5D%2C%20%22env%22%3A%7B%22ESA_ACCESS_TOKEN%22%3A%22your_personal_access_token%22%2C%22LANG%22%3A%22en%22%7D%7D)
+
+Add this to your VS Code MCP config file. See [VS Code MCP docs](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) for more info.
+
+#### VS Code Local Server Connection with `npx`
+
+```json
+"mcp": {
+  "servers": {
+    "esa": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["@esaio/esa-mcp-server"],
+      "env": {
+        "ESA_ACCESS_TOKEN": "your_personal_access_token",
+        "LANG": "en"
+      }
+    }
+  }
+}
+```
+
+</details>
+
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ MCP クライアントの設定ファイルに以下を追加します：
    - [PAT v2](https://docs.esa.io/posts/559)を推奨します。
 - LANG: UI の言語設定
 
-### Claude Desktop の例
+<details>
+<summary><b>Claude Desktop でのインストール</b></summary>
 
 `claude_desktop_config.json` への追加方法：
 
@@ -106,7 +107,7 @@ MCP クライアントの設定ファイルに以下を追加します：
 {
   "mcpServers": {
     "esa": {
-      "command": "/Users/your-username/.nodenv/shims/npx",
+      "command": "/path/to/your/npx",
       "args": [
         "@esaio/esa-mcp-server"
       ],
@@ -119,7 +120,72 @@ MCP クライアントの設定ファイルに以下を追加します：
 }
 ```
 
-> **注意**: `/path/to/your/node` は `which node` で調べたパスに置き換えてください。
+> **注意**: `/path/to/your/npx` は `which npx` で調べたパスに置き換えてください。
+
+
+</details>
+
+
+<details>
+<summary><b>Cursor でのインストール</b></summary>
+
+`設定` -> `Cursor Settings` -> `MCP` -> `Add new global MCP server` に移動します
+
+Cursor の `~/.cursor/mcp.json` ファイルに以下の設定を貼り付けることを推奨します。プロジェクトフォルダに `.cursor/mcp.json` を作成することで、特定のプロジェクトにインストールすることも可能です。詳細は [Cursor MCP docs](https://docs.cursor.com/context/model-context-protocol) を参照してください。
+
+
+#### Cursor ローカルサーバー接続（`npx` 使用）
+
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=esa&config=ewogICAgICAiY29tbWFuZCI6ICJucHgiLAogICAgICAiYXJncyI6IFsKICAgICAgICAiQGVzYWlvL2VzYS1tY3Atc2VydmVyIgogICAgICBdLAogICAgICAiZW52IjogewogICAgICAgICJFU0FfQUNDRVNTX1RPS0VOIjogInlvdXJfcGVyc29uYWxfYWNjZXNzX3Rva2VuIiwKICAgICAgICAiTEFORyI6ICJlbiIKICAgICAgfQogICAgfQ==)
+
+```json
+{
+  "mcpServers": {
+    "esa": {
+      "command": "npx",
+      "args": [
+        "@esaio/esa-mcp-server"
+      ],
+      "env": {
+        "ESA_ACCESS_TOKEN": "your_personal_access_token",
+        "LANG": "ja"
+      }
+    },
+  }
+}
+
+```
+
+</details>
+
+<details>
+<summary><b>VS Code でのインストール</b></summary>
+
+[<img alt="Install in VS Code (npx)" src="https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square&label=Install%20Esa%20MCP&color=0098FF">](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%7B%22name%22%3A%22esa%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22%40esaio%2Fesa-mcp-server%40latest%22%5D%2C%20%22env%22%3A%7B%22ESA_ACCESS_TOKEN%22%3A%22your_personal_access_token%22%2C%22LANG%22%3A%22ja%22%7D%7D)
+
+VS Code の MCP 設定ファイルに以下を追加してください。詳細は [VS Code MCP docs](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) を参照してください。
+
+#### VS Code ローカルサーバー接続（`npx` 使用）
+
+```json
+"mcp": {
+  "servers": {
+    "esa": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["@esaio/esa-mcp-server"],
+      "env": {
+        "ESA_ACCESS_TOKEN": "your_personal_access_token",
+        "LANG": "ja"
+      }
+    }
+  }
+}
+```
+
+</details>
+
+
 
 ## リンク
 


### PR DESCRIPTION
### Summary
This PR enhances both English and Japanese README files by reorganizing the installation instructions into collapsible sections and adding support for additional development environments (Cursor and VS Code).
This PR makes the esa MCP server more accessible to developers using different IDEs while improving the overall documentation experience through better organization and enhanced installation workflows.

### Changes Made

#### 🔄 **Restructured Installation Sections**
- Converted installation instructions to collapsible `<details>` sections for better readability
- Organized content into expandable sections for each supported environment

#### ➕ **Added New Installation Methods**

**Cursor IDE Support:**
- Added comprehensive Cursor installation instructions
- Included deep-link button for one-click MCP server installation
- Provided both global (`~/.cursor/mcp.json`) and project-specific installation options
- Referenced official Cursor MCP documentation

**VS Code Support:**
- Added VS Code installation instructions with badge/link
- Included direct installation link with pre-configured parameters
- Provided JSON configuration example for VS Code MCP setup
- Referenced official VS Code MCP documentation

#### 🛠️ **Technical Improvements**
- Fixed npx path reference from hardcoded user path to generic `/path/to/your/npx`
- Updated command reference from `which node` to `which npx` for accuracy
- Maintained proper localization (English: `LANG: "en"`, Japanese: `LANG: "ja"`)

### Files Modified
- `README.en.md` - English documentation updates
- `README.md` - Japanese documentation updates (translated additions)

### Benefits
- **Better UX**: Collapsible sections reduce visual clutter while maintaining comprehensive information
- **Broader IDE Support**: Users can now easily install in Cursor and VS Code in addition to Claude Desktop
- **One-Click Installation**: Deep-link buttons provide seamless installation experience
- **Improved Accuracy**: Fixed path references and command examples
