### PR TITLE
Fix openapi-fetch instanceof Response check issue in auth middleware

### DIFF
--- a/src/api_client/middleware.ts
+++ b/src/api_client/middleware.ts
@@ -12,7 +12,8 @@ export function createAuthMiddleware(apiAccessToken: string): Middleware {
       if (rateLimit && remaining) {
         console.error(`Rate limit: ${remaining}/${rateLimit}`);
       }
-      return response;
+      // return undefined to avoid openapi-fetch instanceof Response check issue
+      // https://github.com/openapi-ts/openapi-typescript/issues/1847
     },
     async onError({ error }) {
       console.error("Network Error:", error);


### PR DESCRIPTION
## Summary
- Remove explicit `return response` from `onResponse` middleware to avoid unnecessary `instanceof Response` check in openapi-fetch
- Since we don't modify the response, returning `undefined` is safer and skips the check entirely

## Related
- Related to openapi-ts/openapi-typescript#1847 (onRequest side), but the same `instanceof` check pattern exists for `onResponse`:
  https://github.com/openapi-ts/openapi-typescript/blob/5709d33a5977c4908b9e331f01cd0f9e181b1c37/packages/openapi-fetch/src/index.js#L227-L232

## Test plan
- [x] Verify API calls still work correctly with the middleware change
- [x] Confirm rate limit logging still functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)