### PR TITLE
fix: registry.json のエントリをオブジェクト形式に揃える

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -135,7 +135,7 @@ Add to `claude_desktop_config.json`:
 
 ## Registry
 
-This package ships `registry.json` at the package root, listing the names of all registered tools, resources, and prompts along with the package version. It can be consumed programmatically without spawning the server:
+This package ships `registry.json` at the package root, exposing registered tools, resources, and prompts along with the package version. It can be consumed programmatically without spawning the server:
 
 ```js
 import registry from "@esaio/esa-mcp-server/registry.json" with { type: "json" };
@@ -146,11 +146,11 @@ Schema:
 ```json
 {
   "version": "<package version>",
-  "tools": ["esa_get_teams", "..."],
+  "tools": [{ "name": "esa_get_teams" }, "..."],
   "resources": [
     { "name": "esa_recent_posts", "uriTemplate": "esa://teams/{teamName}/posts/recent" }
   ],
-  "prompts": ["esa_summarize_post"]
+  "prompts": [{ "name": "esa_summarize_post" }]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ MCP クライアントの設定ファイルに以下を追加します：
 
 ## レジストリ
 
-このパッケージはルート直下に `registry.json` を同梱しており、登録されているツール / リソース / プロンプトの名前とパッケージバージョンを公開しています。サーバーを起動せずにプログラムから読み取れます:
+このパッケージはルート直下に `registry.json` を同梱しており、登録されているツール / リソース / プロンプトの一覧とパッケージバージョンを公開しています。サーバーを起動せずにプログラムから読み取れます:
 
 ```js
 import registry from "@esaio/esa-mcp-server/registry.json" with { type: "json" };
@@ -146,11 +146,11 @@ import registry from "@esaio/esa-mcp-server/registry.json" with { type: "json" }
 ```json
 {
   "version": "<package version>",
-  "tools": ["esa_get_teams", "..."],
+  "tools": [{ "name": "esa_get_teams" }, "..."],
   "resources": [
     { "name": "esa_recent_posts", "uriTemplate": "esa://teams/{teamName}/posts/recent" }
   ],
-  "prompts": ["esa_summarize_post"]
+  "prompts": [{ "name": "esa_summarize_post" }]
 }
 ```
 

--- a/registry.json
+++ b/registry.json
@@ -1,30 +1,78 @@
 {
   "version": "0.7.3",
   "tools": [
-    "esa_get_teams",
-    "esa_get_team_stats",
-    "esa_get_team_tags",
-    "esa_get_team_members",
-    "esa_get_post",
-    "esa_search_posts",
-    "esa_create_post",
-    "esa_update_post",
-    "esa_get_comment",
-    "esa_create_comment",
-    "esa_update_comment",
-    "esa_delete_comment",
-    "esa_get_post_comments",
-    "esa_get_team_comments",
-    "esa_get_categories",
-    "esa_get_top_categories",
-    "esa_get_all_category_paths",
-    "esa_archive_post",
-    "esa_ship_post",
-    "esa_duplicate_post",
-    "esa_get_search_options_help",
-    "esa_get_markdown_syntax_help",
-    "esa_search_help",
-    "esa_get_attachment"
+    {
+      "name": "esa_get_teams"
+    },
+    {
+      "name": "esa_get_team_stats"
+    },
+    {
+      "name": "esa_get_team_tags"
+    },
+    {
+      "name": "esa_get_team_members"
+    },
+    {
+      "name": "esa_get_post"
+    },
+    {
+      "name": "esa_search_posts"
+    },
+    {
+      "name": "esa_create_post"
+    },
+    {
+      "name": "esa_update_post"
+    },
+    {
+      "name": "esa_get_comment"
+    },
+    {
+      "name": "esa_create_comment"
+    },
+    {
+      "name": "esa_update_comment"
+    },
+    {
+      "name": "esa_delete_comment"
+    },
+    {
+      "name": "esa_get_post_comments"
+    },
+    {
+      "name": "esa_get_team_comments"
+    },
+    {
+      "name": "esa_get_categories"
+    },
+    {
+      "name": "esa_get_top_categories"
+    },
+    {
+      "name": "esa_get_all_category_paths"
+    },
+    {
+      "name": "esa_archive_post"
+    },
+    {
+      "name": "esa_ship_post"
+    },
+    {
+      "name": "esa_duplicate_post"
+    },
+    {
+      "name": "esa_get_search_options_help"
+    },
+    {
+      "name": "esa_get_markdown_syntax_help"
+    },
+    {
+      "name": "esa_search_help"
+    },
+    {
+      "name": "esa_get_attachment"
+    }
   ],
   "resources": [
     {
@@ -33,6 +81,8 @@
     }
   ],
   "prompts": [
-    "esa_summarize_post"
+    {
+      "name": "esa_summarize_post"
+    }
   ]
 }

--- a/scripts/build-registry.ts
+++ b/scripts/build-registry.ts
@@ -12,17 +12,18 @@ import { setupPrompts } from "../src/prompts/index.js";
 import { setupResources } from "../src/resources/index.js";
 import { setupTools } from "../src/tools/index.js";
 
+type NamedRegistryEntry = { name: string };
 type RegistryResource = { name: string; uriTemplate: string };
 type Registry = {
   version: string;
-  tools: string[];
+  tools: NamedRegistryEntry[];
   resources: RegistryResource[];
-  prompts: string[];
+  prompts: NamedRegistryEntry[];
 };
 
-const tools: string[] = [];
+const tools: NamedRegistryEntry[] = [];
 const resources: RegistryResource[] = [];
-const prompts: string[] = [];
+const prompts: NamedRegistryEntry[] = [];
 
 // register{Tool,Resource,Prompt} はオーバーロード + ジェネリックで Parameters<typeof X>
 // が安定しないため、name (と resource の場合は uriOrTemplate) だけを受け取るスタブに
@@ -31,7 +32,7 @@ const prompts: string[] = [];
 const server = new McpServer({ name: "introspect", version: "0.0.0" });
 
 server.registerTool = ((name: string) => {
-  tools.push(name);
+  tools.push({ name });
 }) as unknown as typeof server.registerTool;
 
 server.registerResource = ((
@@ -46,7 +47,7 @@ server.registerResource = ((
 }) as unknown as typeof server.registerResource;
 
 server.registerPrompt = ((name: string) => {
-  prompts.push(name);
+  prompts.push({ name });
 }) as unknown as typeof server.registerPrompt;
 
 await initI18n();


### PR DESCRIPTION
## 概要
- `registry.json` の `tools` と `prompts` を `{ name }` 形式のオブジェクト配列で出力するように変更
- `resources` は従来どおり `{ name, uriTemplate }` を維持
- 生成される schema に合わせて README の例を更新

## 確認
- node --import tsx/esm scripts/build-registry.ts
- npm run type-check