### PR TITLE
chore: drop version field from registry.json

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -135,7 +135,7 @@ Add to `claude_desktop_config.json`:
 
 ## Registry
 
-This package ships `registry.json` at the package root, exposing registered tools, resources, and prompts along with the package version. It can be consumed programmatically without spawning the server:
+This package ships `registry.json` at the package root, exposing registered tools, resources, and prompts. It can be consumed programmatically without spawning the server:
 
 ```js
 import registry from "@esaio/esa-mcp-server/registry.json" with { type: "json" };
@@ -145,7 +145,6 @@ Schema:
 
 ```json
 {
-  "version": "<package version>",
   "tools": [{ "name": "esa_get_teams" }, "..."],
   "resources": [
     { "name": "esa_recent_posts", "uriTemplate": "esa://teams/{teamName}/posts/recent" }

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ MCP クライアントの設定ファイルに以下を追加します：
 
 ## レジストリ
 
-このパッケージはルート直下に `registry.json` を同梱しており、登録されているツール / リソース / プロンプトの一覧とパッケージバージョンを公開しています。サーバーを起動せずにプログラムから読み取れます:
+このパッケージはルート直下に `registry.json` を同梱しており、登録されているツール / リソース / プロンプトの一覧を公開しています。サーバーを起動せずにプログラムから読み取れます:
 
 ```js
 import registry from "@esaio/esa-mcp-server/registry.json" with { type: "json" };
@@ -145,7 +145,6 @@ import registry from "@esaio/esa-mcp-server/registry.json" with { type: "json" }
 
 ```json
 {
-  "version": "<package version>",
   "tools": [{ "name": "esa_get_teams" }, "..."],
   "resources": [
     { "name": "esa_recent_posts", "uriTemplate": "esa://teams/{teamName}/posts/recent" }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "scripts": {
     "build": "tsdown && npm run bin-check",
     "build:registry": "tsx scripts/build-registry.ts",
-    "version": "npm run build:registry && git add registry.json",
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/registry.json
+++ b/registry.json
@@ -1,5 +1,4 @@
 {
-  "version": "0.7.4",
   "tools": [
     {
       "name": "esa_get_teams"

--- a/scripts/build-registry.ts
+++ b/scripts/build-registry.ts
@@ -5,7 +5,6 @@ import {
   McpServer,
   ResourceTemplate,
 } from "@modelcontextprotocol/sdk/server/mcp.js";
-import packageJson from "../package.json" with { type: "json" };
 import type { MCPContext } from "../src/context/mcp-context.js";
 import { initI18n } from "../src/i18n/index.js";
 import { setupPrompts } from "../src/prompts/index.js";
@@ -15,7 +14,6 @@ import { setupTools } from "../src/tools/index.js";
 type NamedRegistryEntry = { name: string };
 type RegistryResource = { name: string; uriTemplate: string };
 type Registry = {
-  version: string;
   tools: NamedRegistryEntry[];
   resources: RegistryResource[];
   prompts: NamedRegistryEntry[];
@@ -58,7 +56,6 @@ setupResources(server, stubContext);
 setupPrompts(server, stubContext);
 
 const registry: Registry = {
-  version: packageJson.version,
   tools,
   resources,
   prompts,


### PR DESCRIPTION
## Summary
- `registry.json` から `version` フィールドを削除
- `npm version` 時に registry を同期する lifecycle script (#307 で追加) も不要になったので削除
- README (JA/EN) のレジストリ説明を更新

## Test plan
- [x] CI の registry sync チェック (`build:registry` 後の `git diff --exit-code registry.json`) が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)