### PR TITLE
Remove broken include param from get_post / search_posts

### DIFF
--- a/src/tools/__tests__/posts.test.ts
+++ b/src/tools/__tests__/posts.test.ts
@@ -42,7 +42,6 @@ describe("getPost", () => {
       {
         params: {
           path: { team_name: "test-team", post_number: 123 },
-          query: { include: undefined },
         },
       },
     );
@@ -57,81 +56,6 @@ describe("getPost", () => {
         },
       ],
     });
-  });
-
-  it("should return a post with comments when include parameter is specified", async () => {
-    const mockPost = createWipPost({
-      body_md: "Post content",
-      body_html: "<p>Post content</p>",
-      comments_count: 2,
-      stargazers_count: 3,
-      watchers_count: 5,
-      comments: [
-        {
-          id: 1,
-          post_number: 123,
-          body_md: "First comment",
-          body_html: "<p>First comment</p>",
-          created_at: "2024-01-03T10:00:00+09:00",
-          updated_at: "2024-01-03T10:00:00+09:00",
-          created_by: {
-            name: "commenter1",
-            screen_name: "commenter1",
-            icon: "https://example.com/icon4.png",
-            myself: false,
-          },
-          url: "",
-          stargazers_count: 0,
-          star: false,
-        },
-        {
-          id: 2,
-          post_number: 123,
-          body_md: "Second comment",
-          body_html: "<p>Second comment</p>",
-          created_at: "2024-01-03T11:00:00+09:00",
-          updated_at: "2024-01-03T11:00:00+09:00",
-          created_by: {
-            name: "commenter2",
-            screen_name: "commenter2",
-            icon: "https://example.com/icon5.png",
-            myself: false,
-          },
-          url: "",
-          stargazers_count: 0,
-          star: false,
-        },
-      ],
-    });
-
-    mockClient.GET.mockResolvedValue({
-      data: mockPost,
-      error: undefined,
-      response: {
-        ok: true,
-        status: 200,
-      } as Response,
-    });
-
-    const result = await getPost(mockClient, {
-      teamName: "test-team",
-      postNumber: 456,
-      include: "comments",
-    });
-
-    expect(mockClient.GET).toHaveBeenCalledWith(
-      "/v1/teams/{team_name}/posts/{post_number}",
-      {
-        params: {
-          path: { team_name: "test-team", post_number: 456 },
-          query: { include: "comments" },
-        },
-      },
-    );
-
-    const parsedResult = JSON.parse((result.content[0] as TextContent).text);
-    expect(parsedResult.wip).toBe("WIP");
-    expect(parsedResult.kind).toBe("flow");
   });
 
   it("should handle API errors", async () => {

--- a/src/tools/__tests__/search.test.ts
+++ b/src/tools/__tests__/search.test.ts
@@ -59,7 +59,6 @@ describe("searchPosts", () => {
           order: undefined,
           page: undefined,
           per_page: undefined,
-          include: undefined,
         },
       },
     });
@@ -106,7 +105,6 @@ describe("searchPosts", () => {
       order: "desc",
       page: 2,
       perPage: 10,
-      include: "comments",
     });
 
     expect(mockClient.GET).toHaveBeenCalledWith("/v1/teams/{team_name}/posts", {
@@ -118,7 +116,6 @@ describe("searchPosts", () => {
           order: "desc",
           page: 2,
           per_page: 10,
-          include: "comments",
         },
       },
     });
@@ -322,7 +319,6 @@ describe("searchPosts", () => {
           order: undefined,
           page: undefined,
           per_page: undefined,
-          include: undefined,
         },
       },
     });

--- a/src/tools/helps.ts
+++ b/src/tools/helps.ts
@@ -10,11 +10,10 @@ export const HELP_DOCS = {
   MARKDOWN_SYNTAX_POST_ID: 49,
 } as const;
 
-// Schema for searchHelp - omit teamName, order, include, and sort from searchPostsSchema
+// Schema for searchHelp - omit teamName, order, and sort from searchPostsSchema
 export const searchHelpSchema = searchPostsSchema.omit({
   teamName: true,
   order: true,
-  include: true,
   sort: true,
 });
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -126,7 +126,7 @@ export function setupTools(server: McpServer, context: MCPContext): void {
     {
       title: "Get a specific esa post",
       description:
-        "Retrieves a specific post from an esa team by post number, with optional comments included.",
+        "Retrieves a specific post from an esa team by post number. To fetch comments, use esa_get_post_comments.",
       inputSchema: getPostSchema.shape,
       annotations: {
         readOnlyHint: true,

--- a/src/tools/posts.ts
+++ b/src/tools/posts.ts
@@ -12,10 +12,6 @@ import { transformPost } from "../transformers/post-transformer.js";
 
 export const getPostSchema = createSchemaWithTeamName({
   postNumber: z.number().describe("The post number to retrieve"),
-  include: z
-    .enum(["comments"])
-    .optional()
-    .describe("Specify 'comments' to include comments in the response"),
 });
 
 export async function getPost(
@@ -31,9 +27,6 @@ export async function getPost(
       {
         params: {
           path: { team_name: args.teamName, post_number: args.postNumber },
-          query: {
-            include: args.include,
-          },
         },
       },
     );

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -51,10 +51,6 @@ For broader results, use OR between related terms rather than listing them with 
     .max(100)
     .optional()
     .describe("Items per page"),
-  include: z
-    .enum(["comments"])
-    .optional()
-    .describe("Specify 'comments' to include comments in the response"),
 });
 
 export async function searchPosts(
@@ -77,7 +73,6 @@ export async function searchPosts(
             order: args.order,
             page: args.page,
             per_page: args.perPage,
-            include: args.include,
           },
         },
       },


### PR DESCRIPTION
## Summary
- `esa_get_post` / `esa_search_posts` の `include` パラメータを廃止しました。
- 該当パラメータは API には渡っていたものの、`transformPost` (`src/transformers/post-transformer.ts`) が `post.comments` / `post.stargazers` を素通しせずに落としており、MCP クライアントには結果が返らない無効パラメータになっていました。
- コメントを取得したい場合は専用ツールの `esa_get_post_comments` を案内するよう description を更新しました。

## Why remove instead of fix?
- MCP のレスポンスサイズは小さく保ちたく、`esa_search_posts` で `per_page` 件分のフルコメントを同梱すると簡単にコンテキストを圧迫します。
- 単一投稿のコメントは `esa_get_post_comments` で取得できるため、責務分離としても自然です。
- `esa_get_comment` の `include=stargazers` と `esa_get_categories` の `include` は実際に機能しており、レスポンスサイズも比較的小さいため今回は据え置きとしました。

## Changes
- `src/tools/posts.ts`: `getPostSchema` から `include` を削除
- `src/tools/search.ts`: `searchPostsSchema` から `include` を削除
- `src/tools/index.ts`: `esa_get_post` の description を更新
- `src/tools/helps.ts`: `searchHelpSchema.omit({...})` から `include: true` を除去
- テスト更新

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run test:run` (269 passed)
- [x] `npm run build:registry` (差分なし)
- [ ] 実環境の MCP クライアントから `esa_get_post` / `esa_search_posts` が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)