### PR TITLE
esa_duplicate_post の description を実装に揃える

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -30,7 +30,7 @@ This MCP server provides seamless integration between AI assistants and [esa.io]
 
 - `esa_archive_post` - Archive a post by moving to Archived/ category
 - `esa_ship_post` - Ship a post (mark as complete by setting wip to false)
-- `esa_duplicate_post` - Prepare a post for duplication (retrieve name and body_md)
+- `esa_duplicate_post` - Duplicate a post (create a new WIP post with the same title and body; cross-team duplication is also supported)
 
 ### Comment Management
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ AI アシスタントと情報共有サービス [esa](https://esa.io) をつな
 
 - `esa_archive_post` - 記事をアーカイブ（Archived/ カテゴリーへ移動）
 - `esa_ship_post` - 記事を Ship It!（WIP を外して公開）
-- `esa_duplicate_post` - 記事を複製するための準備（タイトルと本文を取得）
+- `esa_duplicate_post` - 記事を複製（同じタイトル・本文の WIP 記事を作成。別チームへの複製も可能）
 
 ### コメント管理
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -344,9 +344,9 @@ export function setupTools(server: McpServer, context: MCPContext): void {
   server.registerTool(
     "esa_duplicate_post",
     {
-      title: "Prepare a post for duplication",
+      title: "Duplicate a post",
       description:
-        "Prepares a post for duplication by retrieving its name and body_md content. Returns the name and body_md that can be used with esa_create_post to create a duplicate of the original post.",
+        "Duplicates a post by creating a new WIP post with the same name and body_md as the source post. By default the duplicate is created in the source team; specify targetTeamName to duplicate into a different team.",
       inputSchema: duplicatePostSchema.shape,
       annotations: {
         destructiveHint: true,

--- a/src/tools/post-actions.ts
+++ b/src/tools/post-actions.ts
@@ -84,13 +84,13 @@ export async function shipPost(
 }
 
 export const duplicatePostSchema = createSchemaWithTeamName({
-  postNumber: z
-    .number()
-    .describe("The source post number to prepare for duplication"),
+  postNumber: z.number().describe("The source post number to duplicate"),
   targetTeamName: z
     .string()
     .optional()
-    .describe("The name of the esa team")
+    .describe(
+      "The destination team name for the duplicated post. Defaults to the source team when omitted.",
+    )
     .transform((val) => (val ? normalizeTeamName(val) : undefined)),
 });
 


### PR DESCRIPTION
## Summary
- `esa_duplicate_post` の description / title / 引数 describe が実装と乖離していたため修正しました。
- 旧 description: 「name と body_md を取得して返すだけ。それを esa_create_post に渡して複製する」前提の説明。
- 実装: 内部で `createPost` まで呼んで **WIP 記事を新規作成** する。`targetTeamName` 指定で別チームへの複製にも対応している。

## Why
- LLM 側は description を読んで挙動を判断するため、「準備だけする」と書かれていると不要に `esa_create_post` を続けて呼ぼうとしてしまい、二重作成や混乱を招くおそれがあります。
- `targetTeamName` の存在も「The name of the esa team」とだけ書かれており、複製先チームを指定するためのパラメータだと伝わっていませんでした。

## Changes
- `src/tools/index.ts`: `esa_duplicate_post` の title を "Duplicate a post"、description を「WIP 記事を新規作成する／`targetTeamName` で別チームへも複製可」に変更
- `src/tools/post-actions.ts`: `postNumber` を "The source post number to duplicate"、`targetTeamName` を「複製先チーム。省略時は元のチーム」と明示
- `README.md`: 「記事を複製するための準備（タイトルと本文を取得）」→「記事を複製（同じタイトル・本文の WIP 記事を作成。別チームへの複製も可能）」
- `README.en.md`: 同様に英語側も更新

## Test plan
- [x] \`npm run type-check\`
- [x] \`npm run lint\`
- [x] \`npm run test:run src/tools/__tests__/post-actions.test.ts\`（19 passed）
- [x] MCP クライアント側から \`esa_duplicate_post\` を呼んで、\`createPost\` まで一気に走ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)