### PR TITLE
Support Backlink API

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -22,7 +22,8 @@ This MCP server provides seamless integration between AI assistants and [esa.io]
 ### Post Management
 
 - `esa_search_posts` - Search for posts in esa.io
-- `esa_get_post` - Get a specific post by post number
+- `esa_get_post` - Get a specific post by post number (includes `backlinks_count`)
+- `esa_get_post_backlinks` - List posts that reference a specific post with pagination
 - `esa_create_post` - Create a new post with tags, category, and WIP status
 - `esa_update_post` - Update existing post (title, content, tags, category, WIP status)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ AI アシスタントと情報共有サービス [esa](https://esa.io) をつな
 ### 記事管理
 
 - `esa_search_posts` - 記事を検索
-- `esa_get_post` - 記事 ID から記事を取得
+- `esa_get_post` - 記事 ID から記事を取得（バックリンク総数 `backlinks_count` を含む）
+- `esa_get_post_backlinks` - 指定記事を参照している記事の一覧（ページング対応）
 - `esa_create_post` - 新しい記事を作成（タグ、カテゴリー、WIP ステータス付き）
 - `esa_update_post` - 記事を更新（タイトル、本文、タグ、カテゴリー、WIP ステータス）
 

--- a/registry.json
+++ b/registry.json
@@ -37,6 +37,9 @@
       "name": "esa_delete_comment"
     },
     {
+      "name": "esa_get_post_backlinks"
+    },
+    {
       "name": "esa_get_post_comments"
     },
     {

--- a/src/__tests__/fixtures/mock-backlink.ts
+++ b/src/__tests__/fixtures/mock-backlink.ts
@@ -1,0 +1,43 @@
+import type { components } from "../../generated/api-types.js";
+import { transformPostSummary } from "../../transformers/post-summary-transformer.js";
+
+export function createMockPostSummary(
+  overrides?: Partial<components["schemas"]["PostSummary"]>,
+): components["schemas"]["PostSummary"] {
+  return {
+    number: 42,
+    name: "linked-post.md",
+    full_name: "dev/linked-post.md #linked",
+    wip: false,
+    tags: ["linked"],
+    category: "dev",
+    url: "https://test-team.esa.example.com/posts/42",
+    created_at: "2024-02-01T00:00:00+09:00",
+    updated_at: "2024-02-02T00:00:00+09:00",
+    ...overrides,
+  };
+}
+
+export function createMockBacklinkList(
+  overrides?: Partial<components["schemas"]["BacklinkList"]>,
+): components["schemas"]["BacklinkList"] {
+  return {
+    posts: [
+      createMockPostSummary({ number: 42, name: "linked-1.md" }),
+      createMockPostSummary({ number: 43, name: "linked-2.md" }),
+    ],
+    prev_page: null,
+    next_page: null,
+    total_count: 2,
+    page: 1,
+    per_page: 20,
+    max_per_page: 100,
+    ...overrides,
+  };
+}
+
+export function createExpectedTransformedPostSummary(
+  post: components["schemas"]["PostSummary"],
+) {
+  return transformPostSummary(post);
+}

--- a/src/generated/api-types.ts
+++ b/src/generated/api-types.ts
@@ -2565,13 +2565,13 @@ export interface components {
       stargazers?: (components["schemas"]["Star"] &
         components["schemas"]["Member"])[];
       /**
-       * @description バックリンク（この記事を参照している記事）一覧(include=backlinks)。最大15件。
+       * @description バックリンク（この記事を参照している記事）一覧。記事詳細 API (GET /v1/teams/{team_name}/posts/{post_number}) で `include=backlinks` を指定したときのみ返却される。最大15件。
        *     それ以上を取得したい場合は GET /v1/teams/{team_name}/posts/{post_number}/backlinks を使う。
        *     archived 配下の記事と WIP 状態の記事は除外される。
        */
       backlinks?: components["schemas"]["PostSummary"][];
       /**
-       * @description バックリンク（この記事を参照している記事）の総数(include=backlinks)。
+       * @description バックリンク（この記事を参照している記事）の総数。記事詳細 API (GET /v1/teams/{team_name}/posts/{post_number}) でのみ返却される。 `include` 指定の有無に関わらず常に出力される。
        *     backlinks 配列は最大15件に丸められるため、上限を超えるかどうかの判定に使う。
        *     archived 配下の記事と WIP 状態の記事はカウントに含まれない。
        *     注意: チーム全体での総数を返すため、API アクセスポリシー (PAT v2 / OAuth App v2 の default_deny_and_allow_list) で許可されていないカテゴリのバックリンクもカウントに含まれる。

--- a/src/generated/api-types.ts
+++ b/src/generated/api-types.ts
@@ -491,8 +491,8 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          /** @description 追加で含める情報（カンマ区切り） */
-          include?: components["parameters"]["include"];
+          /** @description 追加で含める情報（カンマ区切り）。記事詳細 API でのみ `backlinks` が利用可能。 */
+          include?: components["parameters"]["post_show_include"];
           /**
            * @description 本文中のsecure attachment URL（https://files.esa.io/ または https://dl.esa.io/）を署名付きURLに変換するかどうか。
            *     - `false`: 変換しない（デフォルト）
@@ -616,6 +616,66 @@ export interface paths {
         500: components["responses"]["InternalServerError"];
       };
     };
+    trace?: never;
+  };
+  "/v1/teams/{team_name}/posts/{post_number}/backlinks": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * バックリンク一覧取得
+     * @description 指定された記事を参照している記事（バックリンク）の一覧を取得します。
+     *     archived 配下の記事と WIP 状態の記事は除外されます。
+     *     並び順はバックリンク登録順の降順（新しい参照が先）です。
+     */
+    get: {
+      parameters: {
+        query?: {
+          /** @description ページ番号（1から開始） */
+          page?: components["parameters"]["page"];
+          /** @description 1ページあたりの要素数 */
+          per_page?: components["parameters"]["per_page"];
+        };
+        header?: never;
+        path: {
+          /** @description チーム名 */
+          team_name: components["parameters"]["team_name"];
+          /** @description 記事番号 */
+          post_number: components["parameters"]["post_number"];
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description 成功 */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["BacklinkList"];
+          };
+        };
+        400: components["responses"]["BadRequestError"];
+        401: components["responses"]["UnauthorizedError"];
+        402: components["responses"]["PaymentRequiredError"];
+        403: components["responses"]["ForbiddenError"];
+        404: components["responses"]["NotFoundError"];
+        405: components["responses"]["MethodNotAllowedError"];
+        406: components["responses"]["NotAcceptableError"];
+        429: components["responses"]["TooManyRequestsError"];
+        500: components["responses"]["InternalServerError"];
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
     trace?: never;
   };
   "/v1/teams/{team_name}/posts/{post_number}/comments": {
@@ -2504,6 +2564,53 @@ export interface components {
       /** @description スターしたメンバー一覧(include=stargazers) */
       stargazers?: (components["schemas"]["Star"] &
         components["schemas"]["Member"])[];
+      /**
+       * @description バックリンク（この記事を参照している記事）一覧(include=backlinks)。最大15件。
+       *     それ以上を取得したい場合は GET /v1/teams/{team_name}/posts/{post_number}/backlinks を使う。
+       *     archived 配下の記事と WIP 状態の記事は除外される。
+       */
+      backlinks?: components["schemas"]["PostSummary"][];
+      /**
+       * @description バックリンク（この記事を参照している記事）の総数(include=backlinks)。
+       *     backlinks 配列は最大15件に丸められるため、上限を超えるかどうかの判定に使う。
+       *     archived 配下の記事と WIP 状態の記事はカウントに含まれない。
+       *     注意: チーム全体での総数を返すため、API アクセスポリシー (PAT v2 / OAuth App v2 の default_deny_and_allow_list) で許可されていないカテゴリのバックリンクもカウントに含まれる。
+       *     アクセスポリシー適用後の正確な件数が必要な場合は、専用エンドポイント GET /v1/teams/{team_name}/posts/{post_number}/backlinks の `total_count` を使う。
+       */
+      backlinks_count?: number;
+    };
+    /** @description 記事の軽量サマリ。バックリンク API(backlinks)などで返却される。 */
+    PostSummary: {
+      /** @description 記事番号 */
+      number: number;
+      /** @description 記事名 */
+      name: string;
+      /** @description カテゴリとタグを含む記事名 */
+      full_name: string;
+      /** @description WIP状態かどうか（バックリンクとして返るのは常に false） */
+      wip: boolean;
+      /** @description タグ */
+      tags: string[];
+      /** @description カテゴリ */
+      category: string | null;
+      /**
+       * Format: uri
+       * @description 記事のURL
+       */
+      url: string;
+      /**
+       * Format: date-time
+       * @description 作成日時
+       */
+      created_at: string;
+      /**
+       * Format: date-time
+       * @description 更新日時
+       */
+      updated_at: string;
+    };
+    BacklinkList: components["schemas"]["Pagination"] & {
+      posts: components["schemas"]["PostSummary"][];
     };
     PostList: components["schemas"]["Pagination"] & {
       posts: components["schemas"]["Post"][];
@@ -2973,7 +3080,14 @@ export interface components {
     /** @description コメントID */
     comment_id: number;
     /** @description 追加で含める情報（カンマ区切り） */
-    include: "comments" | "stargazers" | "comments.stargazers";
+    include: ("comments" | "stargazers" | "comments.stargazers")[];
+    /** @description 追加で含める情報（カンマ区切り）。記事詳細 API でのみ `backlinks` が利用可能。 */
+    post_show_include: (
+      | "comments"
+      | "stargazers"
+      | "comments.stargazers"
+      | "backlinks"
+    )[];
     /**
      * @description 本文中のsecure attachment URL（https://files.esa.io/ または https://dl.esa.io/）を署名付きURLに変換するかどうか。
      *     - `false`: 変換しない（デフォルト）

--- a/src/tools/__tests__/backlinks.test.ts
+++ b/src/tools/__tests__/backlinks.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createExpectedTransformedPostSummary,
+  createMockBacklinkList,
+} from "../../__tests__/fixtures/mock-backlink.js";
+import type { createEsaClient } from "../../api_client/index.js";
+import { getPostBacklinks } from "../backlinks.js";
+
+describe("getPostBacklinks", () => {
+  const mockClient = {
+    GET: vi.fn(),
+  } as unknown as ReturnType<typeof createEsaClient> & {
+    GET: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should get post backlinks successfully", async () => {
+    const mockList = createMockBacklinkList();
+
+    mockClient.GET.mockResolvedValue({
+      data: mockList,
+      error: undefined,
+      response: {
+        ok: true,
+        status: 200,
+      } as Response,
+    });
+
+    const result = await getPostBacklinks(mockClient, {
+      teamName: "test-team",
+      postNumber: 123,
+    });
+
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/v1/teams/{team_name}/posts/{post_number}/backlinks",
+      {
+        params: {
+          path: { team_name: "test-team", post_number: 123 },
+          query: { page: undefined, per_page: undefined },
+        },
+      },
+    );
+
+    const transformedPosts = mockList.posts.map((post) =>
+      createExpectedTransformedPostSummary(post),
+    );
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            { ...mockList, posts: transformedPosts },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+  });
+
+  it("should forward pagination parameters", async () => {
+    const mockList = createMockBacklinkList();
+
+    mockClient.GET.mockResolvedValue({
+      data: mockList,
+      error: undefined,
+      response: {
+        ok: true,
+        status: 200,
+      } as Response,
+    });
+
+    await getPostBacklinks(mockClient, {
+      teamName: "test-team",
+      postNumber: 123,
+      page: 2,
+      perPage: 50,
+    });
+
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/v1/teams/{team_name}/posts/{post_number}/backlinks",
+      {
+        params: {
+          path: { team_name: "test-team", post_number: 123 },
+          query: { page: 2, per_page: 50 },
+        },
+      },
+    );
+  });
+
+  it("should handle API errors", async () => {
+    const mockError = { error: "not_found", message: "Post not found" };
+
+    mockClient.GET.mockResolvedValue({
+      data: undefined,
+      error: mockError,
+      response: {
+        ok: false,
+        status: 404,
+      } as Response,
+    });
+
+    const result = await getPostBacklinks(mockClient, {
+      teamName: "test-team",
+      postNumber: 999,
+    });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: `Error: ${JSON.stringify(mockError, null, 2)}`,
+        },
+      ],
+    });
+  });
+
+  it("should handle network errors", async () => {
+    const networkError = new Error("Network connection failed");
+
+    mockClient.GET.mockRejectedValue(networkError);
+
+    const result = await getPostBacklinks(mockClient, {
+      teamName: "test-team",
+      postNumber: 123,
+    });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: "Error: Network connection failed",
+        },
+      ],
+    });
+  });
+
+  it("should throw MissingTeamNameError when teamName is empty", async () => {
+    const result = await getPostBacklinks(mockClient, {
+      teamName: "",
+      postNumber: 123,
+    });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: "Error: Missing required parameter 'teamName'. Use esa_get_teams to list available teams, then retry with teamName specified.",
+        },
+      ],
+    });
+
+    expect(mockClient.GET).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/__tests__/index.test.ts
+++ b/src/tools/__tests__/index.test.ts
@@ -24,14 +24,14 @@ describe("setupTools", () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it("should register all 24 tools with correct handlers", () => {
+  it("should register all 25 tools with correct handlers", () => {
     const registerToolSpy = vi.spyOn(server, "registerTool");
 
     setupTools(server, context);
 
-    expect(registerToolSpy).toHaveBeenCalledTimes(24);
+    expect(registerToolSpy).toHaveBeenCalledTimes(25);
 
-    for (let i = 0; i < 24; i++) {
+    for (let i = 0; i < 25; i++) {
       const call = registerToolSpy.mock.calls[i] as unknown as [
         string,
         object,

--- a/src/tools/__tests__/posts.test.ts
+++ b/src/tools/__tests__/posts.test.ts
@@ -42,7 +42,6 @@ describe("getPost", () => {
       {
         params: {
           path: { team_name: "test-team", post_number: 123 },
-          query: { include: undefined },
         },
       },
     );
@@ -59,23 +58,8 @@ describe("getPost", () => {
     });
   });
 
-  it("should pass include=backlinks when includeBacklinks is true", async () => {
-    const mockPost = createMockPost({
-      backlinks: [
-        {
-          number: 42,
-          name: "linked-post.md",
-          full_name: "dev/linked-post.md",
-          wip: false,
-          tags: [],
-          category: "dev",
-          url: "https://test-team.esa.example.com/posts/42",
-          created_at: "2024-02-01T00:00:00+09:00",
-          updated_at: "2024-02-02T00:00:00+09:00",
-        },
-      ],
-      backlinks_count: 1,
-    });
+  it("should surface backlinks_count returned by the API", async () => {
+    const mockPost = createMockPost({ backlinks_count: 7 });
 
     mockClient.GET.mockResolvedValue({
       data: mockPost,
@@ -89,31 +73,11 @@ describe("getPost", () => {
     const result = await getPost(mockClient, {
       teamName: "test-team",
       postNumber: 123,
-      includeBacklinks: true,
     });
 
-    expect(mockClient.GET).toHaveBeenCalledWith(
-      "/v1/teams/{team_name}/posts/{post_number}",
-      {
-        params: {
-          path: { team_name: "test-team", post_number: 123 },
-          query: { include: ["backlinks"] },
-        },
-      },
-    );
-
     const parsedResult = JSON.parse((result.content[0] as TextContent).text);
-    expect(parsedResult.backlinks_count).toBe(1);
-    expect(parsedResult.backlinks).toEqual([
-      {
-        number: 42,
-        url: "https://test-team.esa.example.com/posts/42",
-        category_and_title_and_tags: "dev/linked-post.md",
-        wip: "Shipped",
-        created_at: "2024-02-01T00:00:00+09:00",
-        updated_at: "2024-02-02T00:00:00+09:00",
-      },
-    ]);
+    expect(parsedResult.backlinks_count).toBe(7);
+    expect(parsedResult.backlinks).toBeUndefined();
   });
 
   it("should handle API errors", async () => {

--- a/src/tools/__tests__/posts.test.ts
+++ b/src/tools/__tests__/posts.test.ts
@@ -42,6 +42,7 @@ describe("getPost", () => {
       {
         params: {
           path: { team_name: "test-team", post_number: 123 },
+          query: { include: undefined },
         },
       },
     );
@@ -56,6 +57,63 @@ describe("getPost", () => {
         },
       ],
     });
+  });
+
+  it("should pass include=backlinks when includeBacklinks is true", async () => {
+    const mockPost = createMockPost({
+      backlinks: [
+        {
+          number: 42,
+          name: "linked-post.md",
+          full_name: "dev/linked-post.md",
+          wip: false,
+          tags: [],
+          category: "dev",
+          url: "https://test-team.esa.example.com/posts/42",
+          created_at: "2024-02-01T00:00:00+09:00",
+          updated_at: "2024-02-02T00:00:00+09:00",
+        },
+      ],
+      backlinks_count: 1,
+    });
+
+    mockClient.GET.mockResolvedValue({
+      data: mockPost,
+      error: undefined,
+      response: {
+        ok: true,
+        status: 200,
+      } as Response,
+    });
+
+    const result = await getPost(mockClient, {
+      teamName: "test-team",
+      postNumber: 123,
+      includeBacklinks: true,
+    });
+
+    expect(mockClient.GET).toHaveBeenCalledWith(
+      "/v1/teams/{team_name}/posts/{post_number}",
+      {
+        params: {
+          path: { team_name: "test-team", post_number: 123 },
+          query: { include: ["backlinks"] },
+        },
+      },
+    );
+
+    const parsedResult = JSON.parse((result.content[0] as TextContent).text);
+    expect(parsedResult.backlinks_count).toBe(1);
+    expect(parsedResult.backlinks).toEqual([
+      {
+        number: 42,
+        url: "https://test-team.esa.example.com/posts/42",
+        category_and_title_and_tags: "dev/linked-post.md",
+        wip: "Shipped",
+        created_at: "2024-02-01T00:00:00+09:00",
+        updated_at: "2024-02-02T00:00:00+09:00",
+      },
+    ]);
   });
 
   it("should handle API errors", async () => {

--- a/src/tools/backlinks.ts
+++ b/src/tools/backlinks.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import type { createEsaClient } from "../api_client/index.js";
+import { MissingTeamNameError } from "../errors/missing-team-name-error.js";
+import {
+  formatToolError,
+  formatToolResponse,
+} from "../formatters/mcp-response.js";
+import type { components } from "../generated/api-types.js";
+import { createSchemaWithTeamName } from "../schemas/team-name-schema.js";
+import { transformPostSummary } from "../transformers/post-summary-transformer.js";
+
+export const getPostBacklinksSchema = createSchemaWithTeamName({
+  postNumber: z.number().describe("The post number to get backlinks for"),
+  page: z.number().optional().describe("Page number (starts from 1)"),
+  perPage: z.number().optional().describe("Number of items per page"),
+});
+
+export async function getPostBacklinks(
+  client: ReturnType<typeof createEsaClient>,
+  args: z.infer<typeof getPostBacklinksSchema>,
+) {
+  try {
+    if (!args.teamName) {
+      throw new MissingTeamNameError();
+    }
+    const { data, error, response } = await client.GET(
+      "/v1/teams/{team_name}/posts/{post_number}/backlinks",
+      {
+        params: {
+          path: { team_name: args.teamName, post_number: args.postNumber },
+          query: {
+            page: args.page,
+            per_page: args.perPage,
+          },
+        },
+      },
+    );
+
+    if (error || !response.ok) {
+      return formatToolError(error || response.status);
+    }
+
+    const posts: components["schemas"]["PostSummary"][] = data.posts;
+    const transformed = posts.map(transformPostSummary);
+
+    return formatToolResponse({ ...data, posts: transformed });
+  } catch (error) {
+    return formatToolError(error);
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -127,7 +127,7 @@ export function setupTools(server: McpServer, context: MCPContext): void {
     {
       title: "Get a specific esa post",
       description:
-        "Retrieves a specific post from an esa team by post number. To fetch comments, use esa_get_post_comments. Set includeBacklinks=true to also return up to 15 backlinks and backlinks_count; use esa_get_post_backlinks for full pagination.",
+        "Retrieves a specific post from an esa team by post number. The response always includes backlinks_count (the number of posts referencing this one). To list the referencing posts themselves, use esa_get_post_backlinks. To fetch comments, use esa_get_post_comments.",
       inputSchema: getPostSchema.shape,
       annotations: {
         readOnlyHint: true,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,6 +3,7 @@ import type { z } from "zod";
 import { withContext } from "../api_client/with-context.js";
 import type { MCPContext } from "../context/mcp-context.js";
 import { getAttachment, getAttachmentSchema } from "./attachments.js";
+import { getPostBacklinks, getPostBacklinksSchema } from "./backlinks.js";
 import {
   getAllCategoryPaths,
   getAllCategoryPathsSchema,
@@ -126,7 +127,7 @@ export function setupTools(server: McpServer, context: MCPContext): void {
     {
       title: "Get a specific esa post",
       description:
-        "Retrieves a specific post from an esa team by post number. To fetch comments, use esa_get_post_comments.",
+        "Retrieves a specific post from an esa team by post number. To fetch comments, use esa_get_post_comments. Set includeBacklinks=true to also return up to 15 backlinks and backlinks_count; use esa_get_post_backlinks for full pagination.",
       inputSchema: getPostSchema.shape,
       annotations: {
         readOnlyHint: true,
@@ -235,6 +236,21 @@ export function setupTools(server: McpServer, context: MCPContext): void {
     },
     async (params: z.infer<typeof deleteCommentSchema>) =>
       withContext(context, deleteComment, params),
+  );
+
+  server.registerTool(
+    "esa_get_post_backlinks",
+    {
+      title: "Get backlinks for a specific post",
+      description:
+        "Retrieves a paginated list of posts that reference (link back to) the specified post. Archived posts and WIP posts are excluded. Results are ordered by backlink registration date (newest references first).",
+      inputSchema: getPostBacklinksSchema.shape,
+      annotations: {
+        readOnlyHint: true,
+      },
+    },
+    async (params: z.infer<typeof getPostBacklinksSchema>) =>
+      withContext(context, getPostBacklinks, params),
   );
 
   server.registerTool(

--- a/src/tools/posts.ts
+++ b/src/tools/posts.ts
@@ -12,6 +12,12 @@ import { transformPost } from "../transformers/post-transformer.js";
 
 export const getPostSchema = createSchemaWithTeamName({
   postNumber: z.number().describe("The post number to retrieve"),
+  includeBacklinks: z
+    .boolean()
+    .optional()
+    .describe(
+      "Include up to 15 backlinks (posts that reference this post) and backlinks_count in the response. For full pagination use esa_get_post_backlinks.",
+    ),
 });
 
 export async function getPost(
@@ -27,6 +33,9 @@ export async function getPost(
       {
         params: {
           path: { team_name: args.teamName, post_number: args.postNumber },
+          query: {
+            include: args.includeBacklinks ? ["backlinks"] : undefined,
+          },
         },
       },
     );

--- a/src/tools/posts.ts
+++ b/src/tools/posts.ts
@@ -12,12 +12,6 @@ import { transformPost } from "../transformers/post-transformer.js";
 
 export const getPostSchema = createSchemaWithTeamName({
   postNumber: z.number().describe("The post number to retrieve"),
-  includeBacklinks: z
-    .boolean()
-    .optional()
-    .describe(
-      "Include up to 15 backlinks (posts that reference this post) and backlinks_count in the response. For full pagination use esa_get_post_backlinks.",
-    ),
 });
 
 export async function getPost(
@@ -33,9 +27,6 @@ export async function getPost(
       {
         params: {
           path: { team_name: args.teamName, post_number: args.postNumber },
-          query: {
-            include: args.includeBacklinks ? ["backlinks"] : undefined,
-          },
         },
       },
     );

--- a/src/transformers/__tests__/post-transformer.test.ts
+++ b/src/transformers/__tests__/post-transformer.test.ts
@@ -67,4 +67,45 @@ describe("transformPost", () => {
 
     expect(result.body_md).toBe(undefined);
   });
+
+  it("should include backlinks and backlinks_count when present", () => {
+    const post = createMockPost({
+      backlinks: [
+        {
+          number: 42,
+          name: "linked-post.md",
+          full_name: "dev/linked-post.md",
+          wip: false,
+          tags: [],
+          category: "dev",
+          url: "https://test-team.esa.example.com/posts/42",
+          created_at: "2024-02-01T00:00:00+09:00",
+          updated_at: "2024-02-02T00:00:00+09:00",
+        },
+      ],
+      backlinks_count: 1,
+    });
+
+    const result = transformPost(post);
+
+    expect(result.backlinks_count).toBe(1);
+    expect(result.backlinks).toEqual([
+      {
+        number: 42,
+        url: "https://test-team.esa.example.com/posts/42",
+        category_and_title_and_tags: "dev/linked-post.md",
+        wip: "Shipped",
+        created_at: "2024-02-01T00:00:00+09:00",
+        updated_at: "2024-02-02T00:00:00+09:00",
+      },
+    ]);
+  });
+
+  it("should omit backlinks fields when not included in response", () => {
+    const post = createMockPost();
+    const result = transformPost(post);
+
+    expect(result).not.toHaveProperty("backlinks");
+    expect(result).not.toHaveProperty("backlinks_count");
+  });
 });

--- a/src/transformers/__tests__/post-transformer.test.ts
+++ b/src/transformers/__tests__/post-transformer.test.ts
@@ -68,44 +68,17 @@ describe("transformPost", () => {
     expect(result.body_md).toBe(undefined);
   });
 
-  it("should include backlinks and backlinks_count when present", () => {
-    const post = createMockPost({
-      backlinks: [
-        {
-          number: 42,
-          name: "linked-post.md",
-          full_name: "dev/linked-post.md",
-          wip: false,
-          tags: [],
-          category: "dev",
-          url: "https://test-team.esa.example.com/posts/42",
-          created_at: "2024-02-01T00:00:00+09:00",
-          updated_at: "2024-02-02T00:00:00+09:00",
-        },
-      ],
-      backlinks_count: 1,
-    });
-
+  it("should include backlinks_count when present", () => {
+    const post = createMockPost({ backlinks_count: 3 });
     const result = transformPost(post);
 
-    expect(result.backlinks_count).toBe(1);
-    expect(result.backlinks).toEqual([
-      {
-        number: 42,
-        url: "https://test-team.esa.example.com/posts/42",
-        category_and_title_and_tags: "dev/linked-post.md",
-        wip: "Shipped",
-        created_at: "2024-02-01T00:00:00+09:00",
-        updated_at: "2024-02-02T00:00:00+09:00",
-      },
-    ]);
+    expect(result.backlinks_count).toBe(3);
   });
 
-  it("should omit backlinks fields when not included in response", () => {
+  it("should omit backlinks_count when not returned by the API", () => {
     const post = createMockPost();
     const result = transformPost(post);
 
-    expect(result).not.toHaveProperty("backlinks");
     expect(result).not.toHaveProperty("backlinks_count");
   });
 });

--- a/src/transformers/post-summary-transformer.ts
+++ b/src/transformers/post-summary-transformer.ts
@@ -1,0 +1,16 @@
+import type { components } from "../generated/api-types.js";
+
+export function transformPostSummary(
+  post: components["schemas"]["PostSummary"],
+) {
+  return {
+    number: post.number,
+    url: post.url,
+    category_and_title_and_tags: post.full_name,
+    wip: post.wip ? "WIP" : ("Shipped" as const),
+    created_at: post.created_at,
+    updated_at: post.updated_at,
+  };
+}
+
+export type TransformedPostSummary = ReturnType<typeof transformPostSummary>;

--- a/src/transformers/post-transformer.ts
+++ b/src/transformers/post-transformer.ts
@@ -3,6 +3,7 @@ import {
   type BodyTransformOptions,
   processBodyMd,
 } from "./body-transformer.js";
+import { transformPostSummary } from "./post-summary-transformer.js";
 
 export type PostTransformOptions = BodyTransformOptions;
 
@@ -29,6 +30,12 @@ export function transformPost(
       stargazers_count: post.stargazers_count,
       watchers_count: post.watchers_count,
     },
+    ...(post.backlinks !== undefined && {
+      backlinks: post.backlinks.map(transformPostSummary),
+    }),
+    ...(post.backlinks_count !== undefined && {
+      backlinks_count: post.backlinks_count,
+    }),
   };
 }
 

--- a/src/transformers/post-transformer.ts
+++ b/src/transformers/post-transformer.ts
@@ -3,7 +3,6 @@ import {
   type BodyTransformOptions,
   processBodyMd,
 } from "./body-transformer.js";
-import { transformPostSummary } from "./post-summary-transformer.js";
 
 export type PostTransformOptions = BodyTransformOptions;
 
@@ -30,9 +29,6 @@ export function transformPost(
       stargazers_count: post.stargazers_count,
       watchers_count: post.watchers_count,
     },
-    ...(post.backlinks !== undefined && {
-      backlinks: post.backlinks.map(transformPostSummary),
-    }),
     ...(post.backlinks_count !== undefined && {
       backlinks_count: post.backlinks_count,
     }),


### PR DESCRIPTION
## Summary
- Add `esa_get_post_backlinks` tool wrapping `GET /v1/teams/{team_name}/posts/{post_number}/backlinks` with pagination (`page` / `perPage`).
- Surface `backlinks_count` from `esa_get_post` — the upstream OpenAPI spec now returns it unconditionally, so no `include` flag is needed on the MCP side. Following #318, the post detail tool keeps a flat parameter surface and the full referencing-post list lives only on the dedicated tool.
- Regenerate `src/generated/api-types.ts` from the upstream OpenAPI spec (adds `PostSummary` / `BacklinkList`) and refresh `registry.json`.

Closes #322

## Test plan
- [x] `npm run test:run` (277 passed)
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Smoke test against a real esa team: `esa_get_post` returns `backlinks_count`, `esa_get_post_backlinks` paginates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)