### PR TITLE
Recent Posts リソース一覧に title を設定

### DIFF
--- a/src/resources/__tests__/recent-posts-list.test.ts
+++ b/src/resources/__tests__/recent-posts-list.test.ts
@@ -41,12 +41,14 @@ describe("createRecentPostsResourceList", () => {
       {
         uri: "esa://teams/team1/posts/recent",
         name: "Recent posts from team1",
+        title: "Recent posts from team1",
         description: "Recent posts from team1 (Team One)",
         mimeType: "application/json",
       },
       {
         uri: "esa://teams/team2/posts/recent",
         name: "Recent posts from team2",
+        title: "Recent posts from team2",
         description: "Recent posts from team2",
         mimeType: "application/json",
       },

--- a/src/resources/recent-posts-list.ts
+++ b/src/resources/recent-posts-list.ts
@@ -12,6 +12,7 @@ export async function createRecentPostsResourceList(context: MCPContext) {
       data.teams?.map((team: { name: string; description: string }) => ({
         uri: `esa://teams/${team.name}/posts/recent`,
         name: `Recent posts from ${team.name}`,
+        title: `Recent posts from ${team.name}`,
         description: `Recent posts from ${team.name}${team.description ? ` (${team.description})` : ""}`,
         mimeType: "application/json",
       })) || []


### PR DESCRIPTION
## Summary
チーム別の Recent Posts リソースがクライアント上で全て "Recent Posts" と表示され見分けがつかない問題を修正。`createRecentPostsResourceList` の各エントリに `title: "Recent posts from {team}"` を追加。

## 背景
MCP SDK は `listCallback` の返り値をテンプレートの metadata にマージする実装のため、`title` を返していないとテンプレート登録時の `title: "Recent Posts"` が全項目に残り、同名のエントリが並んでしまう。

## Test plan
- [x] `npm run test:run -- src/resources` パス
- [x] `npm run lint` パス
- [ ] 実クライアントでリソース一覧にチーム名付きで表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)