### PR TITLE
esa_summarize_post を簡略化 (format 引数を削除)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2,11 +2,10 @@
   "prompts": {
     "summarize_post": {
       "title": "Summarize esa post",
-      "description": "Summarize an esa post in various formats (bullet points, paragraph, or keywords)",
+      "description": "Summarize an esa post",
       "args": {
         "team_name": "The name of the esa team",
-        "post_number": "The post number to summarize",
-        "format": "Summary format (bullet/paragraph/keywords)"
+        "post_number": "The post number to summarize"
       }
     }
   }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -2,11 +2,10 @@
   "prompts": {
     "summarize_post": {
       "title": "esaの記事の要約",
-      "description": "esa記事を指定した形式で要約します(bullet: 箇条書き, paragraph: 文章, keywords: キーワード)",
+      "description": "esa記事を要約します",
       "args": {
         "team_name": "esaチーム名",
-        "post_number": "要約する記事番号",
-        "format": "要約形式 (bullet/paragraph/keywords)"
+        "post_number": "要約する記事番号"
       }
     }
   }

--- a/src/prompts/__tests__/summarize-post.test.ts
+++ b/src/prompts/__tests__/summarize-post.test.ts
@@ -10,21 +10,9 @@ describe("createSummarizePostSchema", () => {
 
     expect(shape.teamName).toBeDefined();
     expect(shape.postNumber).toBeDefined();
-    expect(shape.format).toBeDefined();
   });
 
   it("should validate correct input", () => {
-    const schema = createSummarizePostSchema();
-    const result = schema.safeParse({
-      teamName: "test-team",
-      postNumber: "123",
-      format: "bullet",
-    });
-
-    expect(result.success).toBe(true);
-  });
-
-  it("should allow optional format", () => {
     const schema = createSummarizePostSchema();
     const result = schema.safeParse({
       teamName: "test-team",
@@ -80,7 +68,7 @@ describe("summarizePost", () => {
     watch: false,
   };
 
-  it("should generate a bullet format summary prompt", async () => {
+  it("should generate a summary prompt", async () => {
     mockClient.GET.mockResolvedValue({
       data: mockPost,
       error: undefined,
@@ -118,49 +106,6 @@ describe("summarizePost", () => {
     expect(promptText).toContain("Category: dev");
     expect(promptText).toContain("Tags: tag1, tag2");
     expect(promptText).toContain("# Test Post");
-    expect(promptText).toContain("Please provide a summary in bullet points");
-  });
-
-  it("should generate a paragraph format summary prompt", async () => {
-    mockClient.GET.mockResolvedValue({
-      data: mockPost,
-      error: undefined,
-      response: {
-        ok: true,
-        status: 200,
-      } as Response,
-    });
-
-    const result = await summarizePost(mockClient, {
-      teamName: "test-team",
-      postNumber: "123",
-      format: "paragraph",
-    });
-
-    const promptText = (result.messages[0].content as TextContent).text;
-    expect(promptText).toContain("Please provide a summary in 2-3 paragraphs");
-  });
-
-  it("should generate a keywords format summary prompt", async () => {
-    mockClient.GET.mockResolvedValue({
-      data: mockPost,
-      error: undefined,
-      response: {
-        ok: true,
-        status: 200,
-      } as Response,
-    });
-
-    const result = await summarizePost(mockClient, {
-      teamName: "test-team",
-      postNumber: "123",
-      format: "keywords",
-    });
-
-    const promptText = (result.messages[0].content as TextContent).text;
-    expect(promptText).toContain(
-      "Please extract and list 10-15 important keywords",
-    );
   });
 
   it("should handle post without category and tags", async () => {
@@ -207,7 +152,7 @@ describe("summarizePost", () => {
 
     const promptText = (result.messages[0].content as TextContent).text;
     expect(promptText).not.toContain("Content:");
-    expect(promptText).toContain("Please provide a summary in bullet points");
+    expect(promptText).toContain("Please summarize the following post:");
   });
 
   it("should handle API errors", async () => {

--- a/src/prompts/summarize-post.ts
+++ b/src/prompts/summarize-post.ts
@@ -15,17 +15,13 @@ export const createSummarizePostSchema = () =>
     postNumber: z
       .string()
       .describe(t("prompts.summarize_post.args.post_number")),
-    format: z
-      .enum(["bullet", "paragraph", "keywords"])
-      .optional()
-      .describe(t("prompts.summarize_post.args.format")),
   });
 
 export async function summarizePost(
   client: ReturnType<typeof createEsaClient>,
   args: z.infer<ReturnType<typeof createSummarizePostSchema>>,
 ) {
-  const { teamName, postNumber: postNumberStr, format = "bullet" } = args;
+  const { teamName, postNumber: postNumberStr } = args;
 
   if (!teamName) {
     throw new MissingTeamNameError();
@@ -70,21 +66,7 @@ export async function summarizePost(
     prompt += "\n---\n\n";
 
     if (post.body_md) {
-      prompt += `Content:\n${post.body_md}\n\n---\n\n`;
-    }
-
-    switch (format) {
-      case "bullet":
-        prompt +=
-          "Please provide a summary in bullet points (3-5 main points).";
-        break;
-      case "paragraph":
-        prompt += "Please provide a summary in 2-3 paragraphs.";
-        break;
-      case "keywords":
-        prompt +=
-          "Please extract and list 10-15 important keywords from this post.";
-        break;
+      prompt += `Content:\n${post.body_md}\n`;
     }
 
     return formatPromptResponse(prompt);


### PR DESCRIPTION
## Summary
- `esa_summarize_post` から `format` 引数を削除し、要約形式の指定は LLM 側に任せる
- i18n の `format` 説明と、プロンプト末尾の形式指示文 (`bullet points...` 等) も合わせて整理
- 4 files changed, 8 insertions(+), 83 deletions(-) の純削減

## Background
- MCP の `Prompt.arguments` スキーマには `enum` フィールドが無く、Claude Desktop など多くのクライアントでは引数値の候補が UI に表示されない
- 一方で `z.enum(["bullet", "paragraph", "keywords"])` の厳密バリデーションが効いているため、正確な値を入力しない限り attach できず、ユーザーには何を入れればよいか分からない状態だった
- 機能としては末尾の指示文を切り替えるだけのもので、必要なら会話で「箇条書きで」と追加すれば十分なため、引数自体を廃止した

## Test plan
- [x] `npm run test:run` (16 tests pass)
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run build:registry` (registry.json に差分なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)