### PR TITLE
bodyMd の schema description にインデント方法を明記

### DIFF
--- a/src/tools/comments.ts
+++ b/src/tools/comments.ts
@@ -52,7 +52,11 @@ export async function getComment(
 
 export const createCommentSchema = createSchemaWithTeamName({
   postNumber: z.number().describe("The post number to comment on"),
-  bodyMd: z.string().describe("The comment content in Markdown format"),
+  bodyMd: z
+    .string()
+    .describe(
+      "The comment content in Markdown format. Use 4 spaces for indentation.",
+    ),
   user: z
     .string()
     .optional()
@@ -97,7 +101,11 @@ export async function createComment(
 
 export const updateCommentSchema = createSchemaWithTeamName({
   commentId: z.number().describe("The comment ID to update"),
-  bodyMd: z.string().describe("The updated comment content in Markdown format"),
+  bodyMd: z
+    .string()
+    .describe(
+      "The updated comment content in Markdown format. Use 4 spaces for indentation.",
+    ),
   user: z
     .string()
     .optional()

--- a/src/tools/posts.ts
+++ b/src/tools/posts.ts
@@ -45,7 +45,12 @@ export async function getPost(
 
 export const createPostSchema = createSchemaWithTeamName({
   name: z.string().describe("The post name (title)"),
-  bodyMd: z.string().optional().describe("The post content in Markdown format"),
+  bodyMd: z
+    .string()
+    .optional()
+    .describe(
+      "The post content in Markdown format. Use 4 spaces for indentation.",
+    ),
   tags: z.array(z.string()).optional().describe("Tags for the post"),
   category: z.string().optional().describe("Category path (e.g., 'dev/docs')"),
   wip: z
@@ -102,7 +107,12 @@ export async function createPost(
 export const updatePostSchema = createSchemaWithTeamName({
   postNumber: z.number().describe("The post number to update"),
   name: z.string().optional().describe("The post name (title)"),
-  bodyMd: z.string().optional().describe("The post content in Markdown format"),
+  bodyMd: z
+    .string()
+    .optional()
+    .describe(
+      "The post content in Markdown format. Use 4 spaces for indentation.",
+    ),
   tags: z.array(z.string()).optional().describe("Tags for the post"),
   category: z.string().optional().describe("Category path (e.g., 'dev/docs')"),
   wip: z


### PR DESCRIPTION
## 概要

- 投稿・コメント系ツールの bodyMd description を更新
- Markdown 本文のインデント方法を明記

Fix #289