### PR TITLE
esa_get_post に truncate オプションを追加

### DIFF
--- a/src/tools/__tests__/helps.test.ts
+++ b/src/tools/__tests__/helps.test.ts
@@ -37,6 +37,7 @@ describe("getSearchOptionsHelp", () => {
     expect(mockGetPost).toHaveBeenCalledWith(mockClient, {
       teamName: HELP_DOCS.TEAM,
       postNumber: HELP_DOCS.SEARCH_OPTIONS_POST_ID,
+      truncate: true,
     });
 
     expect((result.content[0] as TextContent).text).toBe("mocked response");
@@ -94,6 +95,7 @@ describe("getMarkdownSyntaxHelp", () => {
     expect(mockGetPost).toHaveBeenCalledWith(mockClient, {
       teamName: HELP_DOCS.TEAM,
       postNumber: HELP_DOCS.MARKDOWN_SYNTAX_POST_ID,
+      truncate: true,
     });
 
     expect((result.content[0] as TextContent).text).toBe(

--- a/src/tools/__tests__/posts.test.ts
+++ b/src/tools/__tests__/posts.test.ts
@@ -2,6 +2,7 @@ import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createExpectedTransformed,
+  createLongContentPost,
   createMockPost,
   createNullBodyPost,
   createWipPost,
@@ -35,6 +36,7 @@ describe("getPost", () => {
     const result = await getPost(mockClient, {
       teamName: "test-team",
       postNumber: 123,
+      truncate: true,
     });
 
     expect(mockClient.GET).toHaveBeenCalledWith(
@@ -73,6 +75,7 @@ describe("getPost", () => {
     const result = await getPost(mockClient, {
       teamName: "test-team",
       postNumber: 123,
+      truncate: true,
     });
 
     const parsedResult = JSON.parse((result.content[0] as TextContent).text);
@@ -95,6 +98,7 @@ describe("getPost", () => {
     const result = await getPost(mockClient, {
       teamName: "test-team",
       postNumber: 999,
+      truncate: true,
     });
 
     expect(result).toEqual({
@@ -115,6 +119,7 @@ describe("getPost", () => {
     const result = await getPost(mockClient, {
       teamName: "test-team",
       postNumber: 123,
+      truncate: true,
     });
 
     expect(result).toEqual({
@@ -133,6 +138,7 @@ describe("getPost", () => {
     const result = await getPost(mockClient, {
       teamName: "test-team",
       postNumber: 123,
+      truncate: true,
     });
 
     expect(result).toEqual({
@@ -175,6 +181,7 @@ describe("getPost", () => {
     const result = await getPost(mockClient, {
       teamName: "test-team",
       postNumber: 789,
+      truncate: true,
     });
 
     const parsedResult = JSON.parse((result.content[0] as TextContent).text);
@@ -185,6 +192,7 @@ describe("getPost", () => {
     const result = await getPost(mockClient, {
       teamName: "",
       postNumber: 123,
+      truncate: true,
     });
 
     expect(result).toEqual({
@@ -197,6 +205,53 @@ describe("getPost", () => {
     });
 
     expect(mockClient.GET).not.toHaveBeenCalled();
+  });
+
+  it("should truncate body_md by default", async () => {
+    const longPost = createLongContentPost(15000);
+
+    mockClient.GET.mockResolvedValue({
+      data: longPost,
+      error: undefined,
+      response: {
+        ok: true,
+        status: 200,
+      } as Response,
+    });
+
+    const result = await getPost(mockClient, {
+      teamName: "test-team",
+      postNumber: 123,
+      truncate: true,
+    });
+
+    const parsedResult = JSON.parse((result.content[0] as TextContent).text);
+    expect(parsedResult.body_md).toBe(
+      `${"a".repeat(10000)}\n\n... (truncated)`,
+    );
+  });
+
+  it("should return full body_md when truncate is false", async () => {
+    const longPost = createLongContentPost(15000);
+
+    mockClient.GET.mockResolvedValue({
+      data: longPost,
+      error: undefined,
+      response: {
+        ok: true,
+        status: 200,
+      } as Response,
+    });
+
+    const result = await getPost(mockClient, {
+      teamName: "test-team",
+      postNumber: 123,
+      truncate: false,
+    });
+
+    const parsedResult = JSON.parse((result.content[0] as TextContent).text);
+    expect(parsedResult.body_md).toBe("a".repeat(15000));
+    expect(parsedResult.body_md).not.toContain("(truncated)");
   });
 });
 

--- a/src/tools/helps.ts
+++ b/src/tools/helps.ts
@@ -24,6 +24,7 @@ export async function getSearchOptionsHelp(
   return getPost(client, {
     teamName: HELP_DOCS.TEAM,
     postNumber: HELP_DOCS.SEARCH_OPTIONS_POST_ID,
+    truncate: true,
   });
 }
 
@@ -34,6 +35,7 @@ export async function getMarkdownSyntaxHelp(
   return getPost(client, {
     teamName: HELP_DOCS.TEAM,
     postNumber: HELP_DOCS.MARKDOWN_SYNTAX_POST_ID,
+    truncate: true,
   });
 }
 

--- a/src/tools/posts.ts
+++ b/src/tools/posts.ts
@@ -10,8 +10,16 @@ import { createSchemaWithTeamName } from "../schemas/team-name-schema.js";
 import { normalizePostName } from "../transformers/post-name-normalizer.js";
 import { transformPost } from "../transformers/post-transformer.js";
 
+const DEFAULT_GET_POST_TRUNCATE_LENGTH = 10000;
+
 export const getPostSchema = createSchemaWithTeamName({
   postNumber: z.number().describe("The post number to retrieve"),
+  truncate: z
+    .boolean()
+    .default(true)
+    .describe(
+      "Whether to truncate body_md to avoid overwhelming the agent context (default: true). If the response ends with '... (truncated)' and you need the full body (e.g. before calling esa_update_post to preserve the tail), retry with truncate: false.",
+    ),
 });
 
 export async function getPost(
@@ -35,7 +43,10 @@ export async function getPost(
       return formatToolError(error || response.status);
     }
     const post: components["schemas"]["Post"] = data;
-    const transformed = transformPost(post, { truncateBody: 10000 });
+    const transformed = transformPost(
+      post,
+      args.truncate ? { truncateBody: DEFAULT_GET_POST_TRUNCATE_LENGTH } : {},
+    );
 
     return formatToolResponse(transformed);
   } catch (error) {


### PR DESCRIPTION
## 背景

`esa_get_post` は body_md を truncate して返すため、結果をそのまま `esa_update_post` に渡すと末尾が失われることがある。
一方、常に全文を返すとレスポンスが過大になり、利用側のトークン消費や context 制約に影響しうる。

## 変更

- `esa_get_post` に `truncate: boolean` を追加（既定 `true`）
- `false` で全文取得
- description で「末尾が `... (truncated)` の場合は `truncate: false` で再取得」とガイド

## 互換性

既定 `true` のため従来挙動を維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)