### PR TITLE
esa_rollback_post_revision を追加

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -64,6 +64,9 @@
       "name": "esa_duplicate_post"
     },
     {
+      "name": "esa_rollback_post_revision"
+    },
+    {
       "name": "esa_get_search_options_help"
     },
     {

--- a/src/generated/api-types.ts
+++ b/src/generated/api-types.ts
@@ -678,6 +678,250 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/v1/teams/{team_name}/posts/{post_number}/revisions": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * リビジョン一覧取得
+     * @description 指定された記事のリビジョン一覧を取得します。
+     *     並び順はリビジョン番号の降順（新しいものが先）です。
+     */
+    get: {
+      parameters: {
+        query?: {
+          /** @description ページ番号（1から開始） */
+          page?: components["parameters"]["page"];
+          /** @description 1ページあたりの要素数 */
+          per_page?: components["parameters"]["per_page"];
+        };
+        header?: never;
+        path: {
+          /** @description チーム名 */
+          team_name: components["parameters"]["team_name"];
+          /** @description 記事番号 */
+          post_number: components["parameters"]["post_number"];
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description 成功 */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["RevisionList"];
+          };
+        };
+        400: components["responses"]["BadRequestError"];
+        401: components["responses"]["UnauthorizedError"];
+        402: components["responses"]["PaymentRequiredError"];
+        403: components["responses"]["ForbiddenError"];
+        404: components["responses"]["NotFoundError"];
+        405: components["responses"]["MethodNotAllowedError"];
+        406: components["responses"]["NotAcceptableError"];
+        429: components["responses"]["TooManyRequestsError"];
+        500: components["responses"]["InternalServerError"];
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/teams/{team_name}/posts/{post_number}/revisions/{revision_number}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * リビジョン取得
+     * @description 指定されたリビジョンを取得します
+     */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          /** @description チーム名 */
+          team_name: components["parameters"]["team_name"];
+          /** @description 記事番号 */
+          post_number: components["parameters"]["post_number"];
+          /** @description リビジョン番号 */
+          revision_number: components["parameters"]["revision_number"];
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description 成功 */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": {
+              revision: components["schemas"]["Revision"];
+            };
+          };
+        };
+        400: components["responses"]["BadRequestError"];
+        401: components["responses"]["UnauthorizedError"];
+        402: components["responses"]["PaymentRequiredError"];
+        403: components["responses"]["ForbiddenError"];
+        404: components["responses"]["NotFoundError"];
+        405: components["responses"]["MethodNotAllowedError"];
+        406: components["responses"]["NotAcceptableError"];
+        429: components["responses"]["TooManyRequestsError"];
+        500: components["responses"]["InternalServerError"];
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/teams/{team_name}/posts/{post_number}/revisions/compare/{from_revision_number}...{to_revision_number}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * リビジョン間の差分取得
+     * @description 指定された2つのリビジョン間の差分を取得します
+     */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          /** @description チーム名 */
+          team_name: components["parameters"]["team_name"];
+          /** @description 記事番号 */
+          post_number: components["parameters"]["post_number"];
+          /** @description 比較元のリビジョン番号 */
+          from_revision_number: components["parameters"]["from_revision_number"];
+          /** @description 比較先のリビジョン番号 */
+          to_revision_number: components["parameters"]["to_revision_number"];
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description 成功 */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": {
+              diff: components["schemas"]["RevisionDiff"];
+            };
+          };
+        };
+        400: components["responses"]["BadRequestError"];
+        401: components["responses"]["UnauthorizedError"];
+        402: components["responses"]["PaymentRequiredError"];
+        403: components["responses"]["ForbiddenError"];
+        404: components["responses"]["NotFoundError"];
+        405: components["responses"]["MethodNotAllowedError"];
+        406: components["responses"]["NotAcceptableError"];
+        429: components["responses"]["TooManyRequestsError"];
+        500: components["responses"]["InternalServerError"];
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/teams/{team_name}/posts/{post_number}/revisions/{revision_number}/rollback": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * 指定リビジョンへのロールバック
+     * @description 指定されたリビジョンの内容（タイトル・カテゴリ・タグ・本文）に記事を戻し、新しいリビジョンとして保存します。
+     *     履歴は削除されず、ロールバックした内容が最新リビジョンとして積まれます。
+     *     wip 状態はデフォルトで指定リビジョンの状態を継承します（`wip` を指定した場合はその値で上書き）。
+     *     現在（最新）のリビジョンへのロールバックはできません（400 を返します）。
+     */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          /** @description チーム名 */
+          team_name: components["parameters"]["team_name"];
+          /** @description 記事番号 */
+          post_number: components["parameters"]["post_number"];
+          /** @description リビジョン番号 */
+          revision_number: components["parameters"]["revision_number"];
+        };
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": {
+            post?: {
+              /** @description ロールバック後の wip 状態。省略時は指定リビジョンの wip を継承します */
+              wip?: boolean;
+              /** @description 変更メッセージ。省略時は "Roll back to rev {revision_number}: ..." が設定されます */
+              message?: string;
+            };
+          };
+        };
+      };
+      responses: {
+        /** @description ロールバック成功 */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Post"];
+          };
+        };
+        400: components["responses"]["BadRequestError"];
+        401: components["responses"]["UnauthorizedError"];
+        402: components["responses"]["PaymentRequiredError"];
+        403: components["responses"]["ForbiddenError"];
+        404: components["responses"]["NotFoundError"];
+        405: components["responses"]["MethodNotAllowedError"];
+        406: components["responses"]["NotAcceptableError"];
+        429: components["responses"]["TooManyRequestsError"];
+        500: components["responses"]["InternalServerError"];
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/v1/teams/{team_name}/posts/{post_number}/comments": {
     parameters: {
       query?: never;
@@ -2718,6 +2962,57 @@ export interface components {
       /** @description コメント投稿者のscreen_name（owner権限必要） */
       user?: string;
     };
+    Revision: {
+      /** @description リビジョン番号 */
+      number: number;
+      /** @description 記事名（カテゴリ・タグを除く） */
+      name: string;
+      /** @description カテゴリとタグを含む記事名 */
+      full_name: string;
+      /** @description カテゴリ */
+      category: string | null;
+      /** @description タグ */
+      tags: string[];
+      /** @description Markdownの本文 */
+      body_md: string;
+      /** @description HTMLの本文 */
+      body_html: string;
+      /** @description 直前のリビジョンとの差分（HTML） */
+      diff: string | null;
+      /** @description 更新メッセージ */
+      message: string | null;
+      /**
+       * Format: date-time
+       * @description 作成日時
+       */
+      created_at: string;
+      /**
+       * Format: date-time
+       * @description 更新日時
+       */
+      updated_at: string;
+      /** @description WIP状態かどうか */
+      wip: boolean;
+      created_by: components["schemas"]["User"];
+      /**
+       * Format: uri
+       * @description リビジョンのURL
+       */
+      url: string;
+    };
+    RevisionList: components["schemas"]["Pagination"] & {
+      revisions: components["schemas"]["Revision"][];
+    };
+    RevisionDiff: {
+      /** @description 比較元のリビジョン番号 */
+      from_revision_number: number;
+      /** @description 比較先のリビジョン番号 */
+      to_revision_number: number;
+      /** @description 差分（HTML） */
+      diff_html: string;
+      /** @description 差分（テキスト） */
+      diff_text: string;
+    };
     Star: {
       /**
        * Format: date-time
@@ -3079,6 +3374,12 @@ export interface components {
     post_number: number;
     /** @description コメントID */
     comment_id: number;
+    /** @description リビジョン番号 */
+    revision_number: number;
+    /** @description 比較元のリビジョン番号 */
+    from_revision_number: number;
+    /** @description 比較先のリビジョン番号 */
+    to_revision_number: number;
     /** @description 追加で含める情報（カンマ区切り） */
     include: ("comments" | "stargazers" | "comments.stargazers")[];
     /** @description 追加で含める情報（カンマ区切り）。記事詳細 API でのみ `backlinks` が利用可能。 */

--- a/src/tools/__tests__/index.test.ts
+++ b/src/tools/__tests__/index.test.ts
@@ -31,9 +31,9 @@ describe("setupTools", () => {
 
     setupTools(server, context);
 
-    expect(registerToolSpy).toHaveBeenCalledTimes(25);
+    expect(registerToolSpy).toHaveBeenCalledTimes(26);
 
-    for (let i = 0; i < 25; i++) {
+    for (let i = 0; i < 26; i++) {
       const call = registerToolSpy.mock.calls[i] as unknown as [
         string,
         object,

--- a/src/tools/__tests__/post-actions.test.ts
+++ b/src/tools/__tests__/post-actions.test.ts
@@ -2,7 +2,12 @@ import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockPost } from "../../__tests__/fixtures/mock-post.js";
 import type { createEsaClient } from "../../api_client/index.js";
-import { archivePost, duplicatePost, shipPost } from "../post-actions.js";
+import {
+  archivePost,
+  duplicatePost,
+  rollbackPostRevision,
+  shipPost,
+} from "../post-actions.js";
 import * as postsModule from "../posts.js";
 
 vi.mock("../posts.js", () => ({
@@ -458,5 +463,137 @@ describe("duplicatePost", () => {
     });
 
     expect(mockClient.GET).not.toHaveBeenCalled();
+  });
+});
+
+describe("rollbackPostRevision", () => {
+  const mockClient = {
+    POST: vi.fn(),
+  } as unknown as ReturnType<typeof createEsaClient> & {
+    POST: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should roll back to the specified revision", async () => {
+    mockClient.POST.mockResolvedValue({
+      data: createMockPost({ number: 123 }),
+      error: undefined,
+      response: {
+        ok: true,
+        status: 200,
+      } as Response,
+    });
+
+    await rollbackPostRevision(mockClient, {
+      teamName: "test-team",
+      postNumber: 123,
+      revisionNumber: 5,
+    });
+
+    expect(mockClient.POST).toHaveBeenCalledWith(
+      "/v1/teams/{team_name}/posts/{post_number}/revisions/{revision_number}/rollback",
+      {
+        params: {
+          path: {
+            team_name: "test-team",
+            post_number: 123,
+            revision_number: 5,
+          },
+        },
+        body: {
+          post: {
+            wip: undefined,
+            message: undefined,
+          },
+        },
+      },
+    );
+  });
+
+  it("should pass wip and message when provided", async () => {
+    mockClient.POST.mockResolvedValue({
+      data: createMockPost({ number: 123 }),
+      error: undefined,
+      response: {
+        ok: true,
+        status: 200,
+      } as Response,
+    });
+
+    await rollbackPostRevision(mockClient, {
+      teamName: "test-team",
+      postNumber: 123,
+      revisionNumber: 5,
+      wip: false,
+      message: "Restore previous version",
+    });
+
+    expect(mockClient.POST).toHaveBeenCalledWith(
+      "/v1/teams/{team_name}/posts/{post_number}/revisions/{revision_number}/rollback",
+      {
+        params: {
+          path: {
+            team_name: "test-team",
+            post_number: 123,
+            revision_number: 5,
+          },
+        },
+        body: {
+          post: {
+            wip: false,
+            message: "Restore previous version",
+          },
+        },
+      },
+    );
+  });
+
+  it("should handle API error", async () => {
+    mockClient.POST.mockResolvedValue({
+      data: undefined,
+      error: { error: "bad_request", message: "Cannot roll back to current" },
+      response: {
+        ok: false,
+        status: 400,
+      } as Response,
+    });
+
+    const result = await rollbackPostRevision(mockClient, {
+      teamName: "test-team",
+      postNumber: 123,
+      revisionNumber: 5,
+    });
+
+    expect((result.content[0] as TextContent).text).toContain("bad_request");
+  });
+
+  it("should handle network errors", async () => {
+    mockClient.POST.mockRejectedValue(new Error("Network connection failed"));
+
+    const result = await rollbackPostRevision(mockClient, {
+      teamName: "test-team",
+      postNumber: 123,
+      revisionNumber: 5,
+    });
+
+    expect((result.content[0] as TextContent).text).toContain(
+      "Network connection failed",
+    );
+  });
+
+  it("should throw MissingTeamNameError when teamName is empty", async () => {
+    const result = await rollbackPostRevision(mockClient, {
+      teamName: "",
+      postNumber: 123,
+      revisionNumber: 5,
+    });
+
+    expect((result.content[0] as TextContent).text).toContain(
+      "Missing required parameter 'teamName'",
+    );
+    expect(mockClient.POST).not.toHaveBeenCalled();
   });
 });

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -37,6 +37,8 @@ import {
   archivePostSchema,
   duplicatePost,
   duplicatePostSchema,
+  rollbackPostRevision,
+  rollbackPostRevisionSchema,
   shipPost,
   shipPostSchema,
 } from "./post-actions.js";
@@ -368,6 +370,21 @@ export function setupTools(server: McpServer, context: MCPContext): void {
     },
     async (params: z.infer<typeof duplicatePostSchema>) =>
       withContext(context, duplicatePost, params),
+  );
+
+  server.registerTool(
+    "esa_rollback_post_revision",
+    {
+      title: "Roll back a post to a previous revision",
+      description:
+        "Rolls back a post to the specified revision, saving the restored content as a new revision.",
+      inputSchema: rollbackPostRevisionSchema.shape,
+      annotations: {
+        destructiveHint: true,
+      },
+    },
+    async (params: z.infer<typeof rollbackPostRevisionSchema>) =>
+      withContext(context, rollbackPostRevision, params),
   );
 
   server.registerTool(

--- a/src/tools/post-actions.ts
+++ b/src/tools/post-actions.ts
@@ -7,6 +7,7 @@ import {
 } from "../formatters/mcp-response.js";
 import type { components } from "../generated/api-types.js";
 import { createSchemaWithTeamName } from "../schemas/team-name-schema.js";
+import { transformPost } from "../transformers/post-transformer.js";
 import { normalizeTeamName } from "../transformers/team-name-normalizer.js";
 import { createPost, updatePost } from "./posts.js";
 
@@ -126,6 +127,62 @@ export async function duplicatePost(
       bodyMd: postNew.body_md,
       wip: true,
     });
+  } catch (error) {
+    return formatToolError(error);
+  }
+}
+
+export const rollbackPostRevisionSchema = createSchemaWithTeamName({
+  postNumber: z.number().describe("The post number to roll back"),
+  revisionNumber: z
+    .number()
+    .describe(
+      "The revision number to roll back to, e.g. the revision_number from esa_get_post before your edits",
+    ),
+  wip: z
+    .boolean()
+    .optional()
+    .describe(
+      "WIP state after rollback. Defaults to the target revision's WIP state",
+    ),
+  message: z.string().optional().describe("Change message for the rollback"),
+});
+
+export async function rollbackPostRevision(
+  client: ReturnType<typeof createEsaClient>,
+  args: z.infer<typeof rollbackPostRevisionSchema>,
+) {
+  try {
+    if (!args.teamName) {
+      throw new MissingTeamNameError();
+    }
+    const { data, error, response } = await client.POST(
+      "/v1/teams/{team_name}/posts/{post_number}/revisions/{revision_number}/rollback",
+      {
+        params: {
+          path: {
+            team_name: args.teamName,
+            post_number: args.postNumber,
+            revision_number: args.revisionNumber,
+          },
+        },
+        body: {
+          post: {
+            wip: args.wip,
+            message: args.message,
+          },
+        },
+      },
+    );
+
+    if (error || !response.ok) {
+      return formatToolError(error || response.status);
+    }
+
+    const post: components["schemas"]["Post"] = data;
+    const transformed = transformPost(post, { omitBody: true });
+
+    return formatToolResponse(transformed);
   } catch (error) {
     return formatToolError(error);
   }

--- a/src/transformers/__tests__/post-transformer.test.ts
+++ b/src/transformers/__tests__/post-transformer.test.ts
@@ -13,6 +13,7 @@ describe("transformPost", () => {
 
     expect(result).toEqual({
       url: mockPost.url,
+      revision_number: mockPost.revision_number,
       wip: "Shipped",
       kind: "stock",
       category_and_title_and_tags: mockPost.full_name,

--- a/src/transformers/post-transformer.ts
+++ b/src/transformers/post-transformer.ts
@@ -14,6 +14,7 @@ export function transformPost(
 
   return {
     url: post.url,
+    revision_number: post.revision_number,
     wip: post.wip ? "WIP" : ("Shipped" as const),
     kind: post.kind,
     category_and_title_and_tags: post.full_name,


### PR DESCRIPTION
## 概要

記事を指定リビジョンにロールバックする `esa_rollback_post_revision` を追加します。

MCPクライアントが編集前の状態へ戻せるようにするのが目的です。

## 変更点

- `esa_rollback_post_revision` ツールを追加（`POST .../revisions/{revision_number}/rollback`）
  - `postNumber` / `revisionNumber` 必須、`wip` / `message` 任意
- `transformPost` の出力に `revision_number` を追加
  - これまで `esa_get_post` のレスポンスに revision_number が含まれず、ロールバック先の番号を知る手段がなかったため
  - `esa_get_post` で見た番号にそのまま戻せるようになります

## テスト

- post-actions / post-transformer のテストを追加・更新
- test / lint / type-check / build すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)