### PR TITLE
esa_get_post で body_md の文字数・行数を body_md_stats として返す

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -22,7 +22,7 @@ This MCP server provides seamless integration between AI assistants and [esa.io]
 ### Post Management
 
 - `esa_search_posts` - Search for posts in esa.io
-- `esa_get_post` - Get a specific post by post number (includes `backlinks_count`)
+- `esa_get_post` - Get a specific post by post number (includes `backlinks_count` and `body_md_stats` with the body's character and line counts)
 - `esa_get_post_backlinks` - List posts that reference a specific post with pagination
 - `esa_create_post` - Create a new post with tags, category, and WIP status
 - `esa_update_post` - Update existing post (title, content, tags, category, WIP status)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ AI アシスタントと情報共有サービス [esa](https://esa.io) をつな
 ### 記事管理
 
 - `esa_search_posts` - 記事を検索
-- `esa_get_post` - 記事 ID から記事を取得（バックリンク総数 `backlinks_count` を含む）
+- `esa_get_post` - 記事 ID から記事を取得（バックリンク総数 `backlinks_count`、本文の文字数・行数 `body_md_stats` を含む）
 - `esa_get_post_backlinks` - 指定記事を参照している記事の一覧（ページング対応）
 - `esa_create_post` - 新しい記事を作成（タグ、カテゴリー、WIP ステータス付き）
 - `esa_update_post` - 記事を更新（タイトル、本文、タグ、カテゴリー、WIP ステータス）

--- a/src/tools/posts.ts
+++ b/src/tools/posts.ts
@@ -18,7 +18,7 @@ export const getPostSchema = createSchemaWithTeamName({
     .boolean()
     .default(true)
     .describe(
-      "Whether to truncate body_md to avoid overwhelming the agent context (default: true). If the response ends with '... (truncated)' and you need the full body (e.g. before calling esa_update_post to preserve the tail), retry with truncate: false.",
+      "Whether to truncate body_md to avoid overwhelming the agent context (default: true). If the response ends with '... (truncated)' and you need the full body (e.g. before calling esa_update_post to preserve the tail), retry with truncate: false. body_md_stats reports the full body's character and line counts even when truncated.",
     ),
 });
 

--- a/src/transformers/__tests__/post-transformer.test.ts
+++ b/src/transformers/__tests__/post-transformer.test.ts
@@ -18,6 +18,10 @@ describe("transformPost", () => {
       kind: "stock",
       category_and_title_and_tags: mockPost.full_name,
       body_md: mockPost.body_md,
+      body_md_stats: {
+        characters: 41,
+        lines: 3,
+      },
       created_at: mockPost.created_at,
       updated_at: mockPost.updated_at,
       created_by: mockPost.created_by,
@@ -67,6 +71,38 @@ describe("transformPost", () => {
     const result = transformPost(postWithUndefinedBody, { truncateBody: 500 });
 
     expect(result.body_md).toBe(undefined);
+  });
+
+  it("should report stats for the full body even when truncated", () => {
+    const longPost = createLongContentPost(600);
+
+    const result = transformPost(longPost, { truncateBody: 500 });
+
+    expect(result.body_md).toBe(`${"a".repeat(500)}\n\n... (truncated)`);
+    expect(result.body_md_stats).toEqual({ characters: 600, lines: 1 });
+  });
+
+  it("should omit body_md_stats when body_md is omitted", () => {
+    const result = transformPost(createMockPost(), { omitBody: true });
+
+    expect(result.body_md).toBe(undefined);
+    expect(result).not.toHaveProperty("body_md_stats");
+  });
+
+  it("should omit body_md_stats when body_md is undefined", () => {
+    const result = transformPost(createNullBodyPost());
+
+    expect(result).not.toHaveProperty("body_md_stats");
+  });
+
+  it("should count characters by grapheme cluster", () => {
+    // The family emoji is a single grapheme built from 7 code points
+    // (11 UTF-16 code units); it must count as one character.
+    const post = createMockPost({ body_md: "a👨‍👩‍👧‍👦b" });
+
+    const result = transformPost(post);
+
+    expect(result.body_md_stats).toEqual({ characters: 3, lines: 1 });
   });
 
   it("should include backlinks_count when present", () => {

--- a/src/transformers/body-transformer.ts
+++ b/src/transformers/body-transformer.ts
@@ -15,3 +15,45 @@ export function processBodyMd(
   }
   return bodyMd;
 }
+
+export interface BodyMdStats {
+  /**
+   * Number of characters, counted by grapheme cluster ("user-perceived
+   * characters") so emoji sequences (skin tones, flags, ZWJ families) and
+   * combining marks each count as one.
+   */
+  characters: number;
+  /** Number of lines (newline-separated segments). */
+  lines: number;
+}
+
+// Grapheme segmentation is locale-independent, so leave the locale unset.
+// Reused across calls to avoid paying the construction cost per post.
+const graphemeSegmenter = new Intl.Segmenter(undefined, {
+  granularity: "grapheme",
+});
+
+/**
+ * Compute `wc`-like metadata for the full body_md, regardless of whether the
+ * returned body is truncated. Lets the agent gauge the document size and how
+ * much was cut off after truncation.
+ */
+export function computeBodyMdStats(
+  bodyMd: string | undefined,
+): BodyMdStats | undefined {
+  if (bodyMd === undefined || bodyMd === null) {
+    return undefined;
+  }
+  let characters = 0;
+  for (const _ of graphemeSegmenter.segment(bodyMd)) {
+    characters++;
+  }
+  // Newlines need no grapheme segmentation, so count them with a cheap scan.
+  let lines = bodyMd.length === 0 ? 0 : 1;
+  for (let i = 0; i < bodyMd.length; i++) {
+    if (bodyMd.charCodeAt(i) === 10) {
+      lines++;
+    }
+  }
+  return { characters, lines };
+}

--- a/src/transformers/post-transformer.ts
+++ b/src/transformers/post-transformer.ts
@@ -1,6 +1,7 @@
 import type { components } from "../generated/api-types.js";
 import {
   type BodyTransformOptions,
+  computeBodyMdStats,
   processBodyMd,
 } from "./body-transformer.js";
 
@@ -11,6 +12,12 @@ export function transformPost(
   options: PostTransformOptions = {},
 ) {
   const bodyMd = processBodyMd(post.body_md, options);
+  // Omit stats alongside the body so mutation responses (create/update/rollback,
+  // which pass omitBody) don't return stats for a body they don't include.
+  // truncate still keeps stats so they reflect the full, pre-truncation body.
+  const bodyMdStats = options.omitBody
+    ? undefined
+    : computeBodyMdStats(post.body_md);
 
   return {
     url: post.url,
@@ -19,6 +26,7 @@ export function transformPost(
     kind: post.kind,
     category_and_title_and_tags: post.full_name,
     ...(bodyMd !== undefined && { body_md: bodyMd }),
+    ...(bodyMdStats !== undefined && { body_md_stats: bodyMdStats }),
     created_at: post.created_at,
     updated_at: post.updated_at,
     created_by: post.created_by,


### PR DESCRIPTION
Closes #337

`esa_get_post` などのレスポンスに、本文の文字数・行数 `body_md_stats` を追加します。

```json
"body_md_stats": { "characters": 1234, "lines": 56 }
```

- truncate されても本文全体のサイズがわかる（切り詰め量を再取得なしで把握できる）
- `characters` は `Intl.Segmenter`（書記素クラスタ）でカウント。絵文字の ZWJ 連結や結合文字を見た目どおり1文字として数える（locale 非依存のため引数は `undefined`）
- `lines` は改行を直接カウント
- 本文を返さない mutation 系（create/update/rollback）では stats も出さない

付与対象: `esa_get_post` / `esa_search_posts` / category / recent-posts

テスト 282件・type-check・lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)