### PR TITLE
fix: handle cli metadata flags before startup

### DIFF
--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { handleCliArgs } from "../cli.js";
+import { config } from "../config/index.js";
+
+describe("CLI arguments", () => {
+  it.each([["--help"], ["-h"]])("handles %s", (flag) => {
+    expect(handleCliArgs([flag])).toEqual({
+      type: "exit",
+      status: 0,
+      output: expect.stringContaining("Usage: esa-mcp-server"),
+    });
+  });
+
+  it.each([["--version"], ["-v"]])("handles %s", (flag) => {
+    expect(handleCliArgs([flag])).toEqual({
+      type: "exit",
+      status: 0,
+      output: config.server.version,
+    });
+  });
+
+  it("rejects unknown options", () => {
+    expect(handleCliArgs(["--definitely-not-real"])).toEqual({
+      type: "exit",
+      status: 1,
+      output: expect.stringContaining("Unknown option: --definitely-not-real"),
+    });
+  });
+
+  it("continues server startup when no cli flags are provided", () => {
+    expect(handleCliArgs([])).toEqual({ type: "continue" });
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,32 @@
+import { config } from "./config/index.js";
+
+const USAGE = `Usage: esa-mcp-server [options]
+
+Options:
+  -h, --help       Show this help message
+  -v, --version    Show version number`;
+
+export type CliAction =
+  | { type: "continue" }
+  | { output: string; status: number; type: "exit" };
+
+export function handleCliArgs(args: string[]): CliAction {
+  if (args.includes("--help") || args.includes("-h")) {
+    return { type: "exit", status: 0, output: USAGE };
+  }
+
+  if (args.includes("--version") || args.includes("-v")) {
+    return { type: "exit", status: 0, output: config.server.version };
+  }
+
+  const unknownOption = args.find((arg) => arg.startsWith("-"));
+  if (unknownOption) {
+    return {
+      type: "exit",
+      status: 1,
+      output: `Unknown option: ${unknownOption}\n\n${USAGE}`,
+    };
+  }
+
+  return { type: "continue" };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 import { Console } from "node:console";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { handleCliArgs } from "./cli.js";
 import { config, validateConfig } from "./config/index.js";
 import type { StdioContext } from "./context/stdio-context.js";
 import { initI18n } from "./i18n/index.js";
@@ -15,14 +16,24 @@ const logger = new Console({
   stderr: process.stderr,
 });
 
-try {
-  validateConfig();
-} catch (error) {
-  logger.error("Configuration error:", error);
-  process.exit(1);
-}
+const cliAction = handleCliArgs(process.argv.slice(2));
 
 async function main() {
+  if (cliAction.type === "exit") {
+    const stream = cliAction.status === 0 ? process.stdout : process.stderr;
+    stream.write(`${cliAction.output}\n`);
+    process.exit(cliAction.status);
+    return;
+  }
+
+  try {
+    validateConfig();
+  } catch (error) {
+    logger.error("Configuration error:", error);
+    process.exit(1);
+    return;
+  }
+
   await initI18n();
 
   const server = new McpServer({


### PR DESCRIPTION
## Summary
- handle `--help` / `-h` and `--version` / `-v` before server startup
- return a concise error for unknown top-level flags
- keep normal server startup validation unchanged when no metadata flag is used

## Verification
- `npm run test:run`
- `npm run type-check`
- `npx biome check src/cli.ts src/__tests__/cli.test.ts src/index.ts --error-on-warnings`
- `npm run build`

## Dist smoke
Without `ESA_ACCESS_TOKEN` set:
- `node bin/index.js --help` exits 0 and prints usage
- `node bin/index.js --version` exits 0 and prints `0.12.0`
- `node bin/index.js --definitely-not-real` exits 1 and prints an unknown option error
- `node bin/index.js` still exits 1 with the existing missing `ESA_ACCESS_TOKEN` configuration error