### PR TITLE
Treat root Archived category as already archived

### DIFF
--- a/src/tools/__tests__/post-actions.test.ts
+++ b/src/tools/__tests__/post-actions.test.ts
@@ -124,6 +124,33 @@ describe("archivePost", () => {
     );
   });
 
+  it("should not archive a post in the root Archived category again", async () => {
+    const currentPost = createMockPost({
+      number: 123,
+      category: "Archived",
+    });
+
+    mockClient.GET.mockResolvedValue({
+      data: currentPost,
+      error: undefined,
+      response: {
+        ok: true,
+        status: 200,
+      } as Response,
+    });
+
+    const result = await archivePost(mockClient, {
+      teamName: "test-team",
+      postNumber: 123,
+    });
+
+    expect(mockUpdatePost).not.toHaveBeenCalled();
+    expect((result.content[0] as TextContent).text).toContain(
+      "Post is already archived",
+    );
+    expect((result.content[0] as TextContent).text).toContain('"Archived"');
+  });
+
   it("should handle GET error", async () => {
     const mockError = { error: "not_found", message: "Post not found" };
 

--- a/src/tools/post-actions.ts
+++ b/src/tools/post-actions.ts
@@ -40,7 +40,10 @@ export async function archivePost(
     const post: components["schemas"]["Post"] = data;
     const currentCategory = post.category || "";
 
-    if (currentCategory.startsWith("Archived/")) {
+    if (
+      currentCategory === "Archived" ||
+      currentCategory.startsWith("Archived/")
+    ) {
       return formatToolResponse({
         message: "Post is already archived",
         category: currentCategory,


### PR DESCRIPTION
## Summary

Posts without a category are moved to the root Archived category. The existing already-archived check only recognized Archived/... paths, so archiving such a post again moved it to Archived/Archived.

This change handles the exact root category as already archived and adds a regression test.

## Verification

- npm run test:release (293 tests, type-check, and lint)