### PR TITLE
feat: esa_archive_post を専用の archive API に切り替える

### DIFF
--- a/src/generated/api-types.ts
+++ b/src/generated/api-types.ts
@@ -738,7 +738,8 @@ export interface paths {
      * 記事のアーカイブ
      * @description 指定された記事を `Archived/` 配下へ移動し、新しいリビジョンとして保存します。
      *     元のカテゴリは維持され、`Foo/Bar` の記事は `Archived/Foo/Bar` になります。
-     *     既に `Archived/` 配下にある記事に対しては何も変更せず、現在の記事を返します（`Archived/Archived/...` にはなりません）。
+     *     変更メッセージは `post.message` で任意に指定できます。
+     *     既に `Archived/` 配下にある記事に対しては何も変更せず、現在の記事を返します（`Archived/Archived/...` にはなりません）。このとき `post.message` を指定しても無視されます。
      */
     post: {
       parameters: {
@@ -752,7 +753,16 @@ export interface paths {
         };
         cookie?: never;
       };
-      requestBody?: never;
+      requestBody?: {
+        content: {
+          "application/json": {
+            post?: {
+              /** @description 変更メッセージ。空文字（空白のみの文字列を含む）は未指定と同じ扱いです。省略時は直前の変更メッセージを引き継ぎます（未設定または既定の作成 / 更新メッセージ "Create post." / "Update post." だった場合は "Archived!" になります）。この 2 つの既定文言は明示的に指定した場合も "Archived!" に置き換わります */
+              message?: string;
+            };
+          };
+        };
+      };
       responses: {
         /** @description アーカイブ成功 */
         200: {

--- a/src/tools/__tests__/post-actions.test.ts
+++ b/src/tools/__tests__/post-actions.test.ts
@@ -20,8 +20,10 @@ vi.mock("../posts.js", () => ({
 describe("archivePost", () => {
   const mockClient = {
     GET: vi.fn(),
+    POST: vi.fn(),
   } as unknown as ReturnType<typeof createEsaClient> & {
     GET: ReturnType<typeof vi.fn>;
+    POST: ReturnType<typeof vi.fn>;
   };
 
   const mockUpdatePost = vi.mocked(postsModule.updatePost);
@@ -30,79 +32,13 @@ describe("archivePost", () => {
     vi.clearAllMocks();
   });
 
-  it("should call updatePost with Archived category for post without category", async () => {
-    const currentPost = createMockPost({
-      number: 123,
-      category: "",
-    });
-
-    mockClient.GET.mockResolvedValue({
-      data: currentPost,
-      error: undefined,
-      response: {
-        ok: true,
-        status: 200,
-      } as Response,
-    });
-
-    mockUpdatePost.mockResolvedValue({
-      content: [{ type: "text", text: "Updated post" }],
-    });
-
-    await archivePost(mockClient, {
-      teamName: "test-team",
-      postNumber: 123,
-    });
-
-    expect(mockUpdatePost).toHaveBeenCalledWith(mockClient, {
-      teamName: "test-team",
-      postNumber: 123,
-      category: "Archived",
-      message: "Archive post",
-    });
-  });
-
-  it("should call updatePost with Archived/ prefix for post with category", async () => {
-    const currentPost = createMockPost({
-      number: 123,
-      category: "dev/docs",
-    });
-
-    mockClient.GET.mockResolvedValue({
-      data: currentPost,
-      error: undefined,
-      response: {
-        ok: true,
-        status: 200,
-      } as Response,
-    });
-
-    mockUpdatePost.mockResolvedValue({
-      content: [{ type: "text", text: "Updated post" }],
-    });
-
-    await archivePost(mockClient, {
-      teamName: "test-team",
-      postNumber: 123,
-      message: "Custom archive message",
-    });
-
-    expect(mockUpdatePost).toHaveBeenCalledWith(mockClient, {
-      teamName: "test-team",
-      postNumber: 123,
-      category: "Archived/dev/docs",
-      message: "Custom archive message",
-    });
-  });
-
-  it("should return already archived message without calling updatePost", async () => {
-    const currentPost = createMockPost({
-      number: 123,
-      category: "Archived/dev/docs",
-    });
-
-    mockClient.GET.mockResolvedValue({
-      data: currentPost,
+  it("should call the archive API", async () => {
+    mockClient.POST.mockResolvedValue({
+      data: createMockPost({
+        number: 123,
+        category: "Archived/dev",
+        full_name: "Archived/dev/test-post.md #tag1 #tag2",
+      }),
       error: undefined,
       response: {
         ok: true,
@@ -115,19 +51,55 @@ describe("archivePost", () => {
       postNumber: 123,
     });
 
+    // Archived/ の付け替えとアーカイブ済みの判定は API 側の責務
+    expect(mockClient.GET).not.toHaveBeenCalled();
     expect(mockUpdatePost).not.toHaveBeenCalled();
-    expect((result.content[0] as TextContent).text).toContain(
-      "Post is already archived",
+    expect(mockClient.POST).toHaveBeenCalledWith(
+      "/v1/teams/{team_name}/posts/{post_number}/archive",
+      {
+        params: {
+          path: {
+            team_name: "test-team",
+            post_number: 123,
+          },
+        },
+        body: {
+          post: {
+            message: undefined,
+          },
+        },
+      },
     );
     expect((result.content[0] as TextContent).text).toContain(
-      "Archived/dev/docs",
+      "Archived/dev/test-post.md",
     );
   });
 
-  it("should handle GET error", async () => {
+  it("should pass message when provided", async () => {
+    mockClient.POST.mockResolvedValue({
+      data: createMockPost({ number: 123 }),
+      error: undefined,
+      response: {
+        ok: true,
+        status: 200,
+      } as Response,
+    });
+
+    await archivePost(mockClient, {
+      teamName: "test-team",
+      postNumber: 123,
+      message: "Retire this post",
+    });
+
+    expect(mockClient.POST.mock.calls[0][1].body.post.message).toBe(
+      "Retire this post",
+    );
+  });
+
+  it("should handle archive API error", async () => {
     const mockError = { error: "not_found", message: "Post not found" };
 
-    mockClient.GET.mockResolvedValue({
+    mockClient.POST.mockResolvedValue({
       data: undefined,
       error: mockError,
       response: {
@@ -142,13 +114,12 @@ describe("archivePost", () => {
     });
 
     expect((result.content[0] as TextContent).text).toContain("not_found");
-    expect(mockUpdatePost).not.toHaveBeenCalled();
   });
 
   it("should handle network errors", async () => {
     const networkError = new Error("Network connection failed");
 
-    mockClient.GET.mockRejectedValue(networkError);
+    mockClient.POST.mockRejectedValue(networkError);
 
     const result = await archivePost(mockClient, {
       teamName: "test-team",
@@ -158,11 +129,10 @@ describe("archivePost", () => {
     expect((result.content[0] as TextContent).text).toContain(
       "Network connection failed",
     );
-    expect(mockUpdatePost).not.toHaveBeenCalled();
   });
 
   it("should handle non-Error exceptions", async () => {
-    mockClient.GET.mockRejectedValue("Unexpected error");
+    mockClient.POST.mockRejectedValue("Unexpected error");
 
     const result = await archivePost(mockClient, {
       teamName: "test-team",
@@ -172,7 +142,6 @@ describe("archivePost", () => {
     expect((result.content[0] as TextContent).text).toContain(
       "Unexpected error",
     );
-    expect(mockUpdatePost).not.toHaveBeenCalled();
   });
 
   it("should throw MissingTeamNameError when teamName is empty", async () => {
@@ -190,7 +159,7 @@ describe("archivePost", () => {
       ],
     });
 
-    expect(mockClient.GET).not.toHaveBeenCalled();
+    expect(mockClient.POST).not.toHaveBeenCalled();
   });
 });
 

--- a/src/tools/post-actions.ts
+++ b/src/tools/post-actions.ts
@@ -13,7 +13,7 @@ import { createPost, updatePost } from "./posts.js";
 
 export const archivePostSchema = createSchemaWithTeamName({
   postNumber: z.number().describe("The post number to archive"),
-  message: z.string().optional().describe("Archive message for the post"),
+  message: z.string().optional().describe("Change message for the archive"),
 });
 
 export async function archivePost(
@@ -24,11 +24,19 @@ export async function archivePost(
     if (!args.teamName) {
       throw new MissingTeamNameError();
     }
-    const { data, error, response } = await client.GET(
-      "/v1/teams/{team_name}/posts/{post_number}",
+    // Archived/ の付け替えも、すでにアーカイブ済みのときに何も変えないことも
+    // API 側の責務。ツール側はカテゴリを組み立てない。
+    const { data, error, response } = await client.POST(
+      "/v1/teams/{team_name}/posts/{post_number}/archive",
       {
         params: {
           path: { team_name: args.teamName, post_number: args.postNumber },
+        },
+        body: {
+          // message は既定を付けず、指定時のみ送る（未指定なら esa 側の既定に委ねる）
+          post: {
+            message: args.message,
+          },
         },
       },
     );
@@ -38,24 +46,9 @@ export async function archivePost(
     }
 
     const post: components["schemas"]["Post"] = data;
-    const currentCategory = post.category || "";
+    const transformed = transformPost(post, { omitBody: true });
 
-    if (currentCategory.startsWith("Archived/")) {
-      return formatToolResponse({
-        message: "Post is already archived",
-        category: currentCategory,
-      });
-    }
-
-    const archivedCategory =
-      currentCategory === "" ? "Archived" : `Archived/${currentCategory}`;
-
-    return await updatePost(client, {
-      teamName: args.teamName,
-      postNumber: args.postNumber,
-      category: archivedCategory,
-      message: args.message || "Archive post",
-    });
+    return formatToolResponse(transformed);
   } catch (error) {
     return formatToolError(error);
   }


### PR DESCRIPTION
## 概要

`esa_archive_post` を、専用エンドポイント
`POST /v1/teams/{team_name}/posts/{post_number}/archive` に切り替えます。
`Archived/` の組み立ても、すでにアーカイブ済みの記事に何も変えないことも API 側の責務になります。

## 設計

**アーカイブ済みかどうかは区別しません。** `esa_update_post` と同じく結果だけを返します。
判定のために記事を先読みする必要がなく、2リクエストが1リクエストになります。

これに伴い、カテゴリを組み立てて update API を叩く処理と、
`Post is already archived` を返す分岐を削除しました。

`message` は API が受け取るようになったのでスキーマに残し、既定は付けず指定時のみ送ります
（未指定なら esa 側の既定に委ねる）。

`src/generated/api-types.ts` は archive の requestBody 追加分を再生成しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)